### PR TITLE
[Fix] validate_secret can accept int

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,14 @@
 *.log
 *.pyc
+*.so
 /.cache
 /.coverage
 /.eggs
 /.idea
+/.pytest_cache
 /coincurve.egg-info
 /build
 /dist
 /docs/build
+/venv
 /wheelhouse

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /.coverage
 /.eggs
 /.idea
+/.mypy_cache
 /.pytest_cache
 /coincurve.egg-info
 /build

--- a/coincurve/utils.py
+++ b/coincurve/utils.py
@@ -102,7 +102,13 @@ def pad_scalar(scalar):
 
 
 def validate_secret(secret):
-    if not 0 < bytes_to_int(secret) < GROUP_ORDER_INT:
+    if isinstance(secret, int):
+        int_secret = secret
+        secret = int_to_bytes(secret)
+    else:
+        int_secret = bytes_to_int(secret)
+
+    if not 0 < int_secret < GROUP_ORDER_INT:
         raise ValueError('Secret scalar must be greater than 0 and less than '
                          '{}.'.format(GROUP_ORDER_INT))
     return pad_scalar(secret)

--- a/coincurve/utils.py
+++ b/coincurve/utils.py
@@ -1,3 +1,4 @@
+import sys
 from base64 import b64decode, b64encode
 from binascii import hexlify, unhexlify
 from hashlib import sha256 as _sha256
@@ -5,6 +6,10 @@ from os import urandom
 
 from coincurve.context import GLOBAL_CONTEXT
 from ._libsecp256k1 import ffi, lib
+
+PY3 = sys.version_info[0] == 3
+if PY3:
+    long = int
 
 GROUP_ORDER = (b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff'
                b'\xfe\xba\xae\xdc\xe6\xafH\xa0;\xbf\xd2^\x8c\xd06AA')
@@ -38,7 +43,6 @@ if hasattr(int, "to_bytes"):
     def int_to_bytes(num):
         return num.to_bytes((num.bit_length() + 7) // 8 or 1, 'big')
 
-
     def int_to_bytes_padded(num):
         return pad_scalar(
             num.to_bytes((num.bit_length() + 7) // 8 or 1, 'big')
@@ -46,7 +50,6 @@ if hasattr(int, "to_bytes"):
 else:
     def int_to_bytes(num):
         return unhexlify(pad_hex('%x' % num))
-
 
     def int_to_bytes_padded(num):
         return pad_scalar(unhexlify(pad_hex('%x' % num)))
@@ -102,7 +105,7 @@ def pad_scalar(scalar):
 
 
 def validate_secret(secret):
-    if isinstance(secret, int):
+    if isinstance(secret, (int, long)):
         int_secret = secret
         secret = int_to_bytes(secret)
     else:


### PR DESCRIPTION
Rationale: Make it possible to call methods like
```python
>>> from coincurve import PrivateKey
>>> k1 = PrivateKey(1)
>>> k2 = PrivateKey(2)
>>> sha256(k1.public_key.multiply(k2.to_int()).format()) == k1.ecdh(k2.public_key.format()).hex()
True
>>> k1.ecdh(k2.public_key.format()).hex()
'b1c9938f01121e159887ac2c8d393a22e4476ff8212de13fe1939de2a236f0a7'
```