### PR TITLE
Make key objects serializable using pickle

### DIFF
--- a/coincurve/keys.py
+++ b/coincurve/keys.py
@@ -21,7 +21,7 @@ from ._libsecp256k1 import ffi, lib
 DEFAULT_NONCE = (ffi.NULL, ffi.NULL)
 
 
-class PrivateKey:
+class PrivateKey(object):
     def __init__(self, secret=None, context=GLOBAL_CONTEXT):
         self.secret = validate_secret(secret) if secret is not None else get_valid_secret()
         self.context = context
@@ -158,8 +158,10 @@ class PrivateKey:
     def __eq__(self, other):
         return self.secret == other.secret
 
+    def __reduce__(self):
+        return type(self), (hex_to_bytes(self.to_hex()),)
 
-class PublicKey:
+class PublicKey(object):
     def __init__(self, data, context=GLOBAL_CONTEXT):
         if not isinstance(data, bytes):
             self.public_key = data
@@ -296,3 +298,6 @@ class PublicKey:
 
     def __eq__(self, other):
         return self.format(compressed=False) == other.format(compressed=False)
+
+    def __reduce__(self):
+        return type(self), (self.format(),)

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -1,5 +1,6 @@
 from hashlib import sha512
 from os import urandom
+from pickle import dumps, loads
 
 import pytest
 
@@ -109,6 +110,15 @@ class TestPrivateKey:
         assert new_private_key.to_int() == 25
         assert private_key is new_private_key
 
+    def test_pickle(self):
+        private_key = PrivateKey(PRIVATE_KEY_BYTES)
+        serialized = dumps(private_key)
+        deserialized = loads(serialized)
+        assert private_key.public_key.verify(
+            deserialized.sign(MESSAGE),
+            MESSAGE,
+        )
+
 
 class TestPublicKey:
     def test_from_secret(self):
@@ -140,3 +150,9 @@ class TestPublicKey:
         point = G.multiply(x)
 
         assert point.add(k) == G.multiply(int_to_bytes_padded((bytes_to_int(x) + bytes_to_int(k)) % n))
+
+    def test_pickle(self):
+        public_key = PublicKey(PUBLIC_KEY_COMPRESSED)
+        serialized = dumps(public_key)
+        deserialized = loads(serialized)
+        assert deserialized.verify(SIGNATURE, MESSAGE)


### PR DESCRIPTION
This implements [`pickle`][1] protocol so that it can be serialized and deserialized using `pickle` module.  In fact, the protocol is used by [`copy.deepcopy()`][2] function as well.

Plus, `PrivateKey` and `PublicKey` became to explicitly inherit `object`.  While this change does nothing on Python 3 which has no old-style class but only new-style class, it purposes to mark these classes new-style.  See also [docs about new-style classes][3].  It was necessary for implementing `pickle` protocol.

[1]: https://docs.python.org/3/library/pickle.html
[2]: https://docs.python.org/3/library/copy.html
[3]: https://www.python.org/doc/newstyle/