### PR TITLE
Introduce tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /.coverage
 /.eggs
 /.idea
+/.tox
 /coincurve.egg-info
 /build
 /dist

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+skip_missing_interpreters = true
 envlist =
     py{27,35,36,37},
     pypy3

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+[tox]
+envlist =
+    py27, py35, py36, py37, pypy3
+
+[testenv]
+usedevelop = true
+deps =
+    pytest>=2.8.7
+commands =
+    pytest {posargs:}

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
-    py27, py35, py36, py37, pypy3
+    py{27,35,36,37},
+    pypy3
 
 [testenv]
 usedevelop = true


### PR DESCRIPTION
[tox] is a de facto standard to run tests on multiple Python interpreters.  Since coincurve supports many Python versions, tox can make tests more rapid.  The following demo session shows how it can be tested on multiple interpreters at once, using [detox], a parallelized tox:

[![Detox demo session](https://asciinema.org/a/YICl68UZg9B6gWuLLxGdtGD7u.png)](https://asciinema.org/a/YICl68UZg9B6gWuLLxGdtGD7u)

[tox]: https://tox.readthedocs.io/
[detox]: https://github.com/tox-dev/detox