### PR TITLE
Make libgmp optional

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -183,7 +183,6 @@ class build_clib(_build_clib):
             os.path.abspath(self.build_clib),
             '--enable-experimental',
             '--enable-module-ecdh',
-            '--with-bignum=gmp',
             '--enable-benchmark=no',
             #  '--enable-endomorphism',
         ]


### PR DESCRIPTION
We should let libsecp256k1 autodetect if libgmp is present [here](https://github.com/bitcoin-core/secp256k1/blob/1e6f1f5ad5e7f1e3ef79313ec02023902bf8175c/configure.ac#L282-L306) rather than making it a hard dependency.