### PR TITLE
Compatibility with latest libsecp256k1 (20181105)

### DIFF
--- a/_cffi_build/secp256k1_ecdh.h
+++ b/_cffi_build/secp256k1_ecdh.h
@@ -2,5 +2,7 @@ int secp256k1_ecdh(
   const secp256k1_context* ctx,
   unsigned char *result,
   const secp256k1_pubkey *pubkey,
-  const unsigned char *privkey
+  const unsigned char *privkey,
+  void *hashfp,
+  void *data
 );

--- a/coincurve/_windows_libsecp256k1.py
+++ b/coincurve/_windows_libsecp256k1.py
@@ -223,7 +223,9 @@ int secp256k1_ecdh(
   const secp256k1_context* ctx,
   unsigned char *result,
   const secp256k1_pubkey *pubkey,
-  const unsigned char *privkey
+  const unsigned char *privkey,
+  void *hashfp,
+  void *data
 );
 """
 

--- a/coincurve/keys.py
+++ b/coincurve/keys.py
@@ -70,7 +70,7 @@ class PrivateKey:
 
         lib.secp256k1_ecdh(
             self.context.ctx, secret, PublicKey(public_key).public_key,
-            self.secret
+            self.secret, ffi.NULL, ffi.NULL
         )
 
         return bytes(ffi.buffer(secret, 32))

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ MAKE = 'gmake' if platform.system() in ['FreeBSD'] else 'make'
 
 # Version of libsecp256k1 to download if none exists in the `libsecp256k1`
 # directory
-LIB_TARBALL_URL = 'https://github.com/bitcoin-core/secp256k1/archive/1e6f1f5ad5e7f1e3ef79313ec02023902bf8175c.tar.gz'
+LIB_TARBALL_URL = 'https://github.com/bitcoin-core/secp256k1/archive/314a61d72474aa29ff4afba8472553ad91d88e9d.tar.gz'
 
 
 # We require setuptools >= 3.3


### PR DESCRIPTION
Latest secp256k lib added two more options into secp256k1_ecdh breaking backward compatibility. 
This patch updates coincurve code so it will not crash on building against latest secp256k1 lib.