### PR TITLE
Allow override system libsecp with env. variable

### DIFF
--- a/setup_support.py
+++ b/setup_support.py
@@ -68,13 +68,13 @@ def build_flags(library, type_, path):
 
 
 def _find_lib():
+    if 'COINCURVE_IGNORE_SYSTEM_LIB' in os.environ:
+        return False
+
     from cffi import FFI
     ffi = FFI()
     try:
-        if "COINCURVE_IGNORE_SYSTEM_LIB" in os.environ:
-            return False
-        else:
-            ffi.dlopen("secp256k1")
+        ffi.dlopen("secp256k1")
     except OSError:
         if 'LIB_DIR' in os.environ:
             for path in glob.glob(os.path.join(os.environ['LIB_DIR'], "*secp256k1*")):

--- a/setup_support.py
+++ b/setup_support.py
@@ -71,7 +71,10 @@ def _find_lib():
     from cffi import FFI
     ffi = FFI()
     try:
-        ffi.dlopen("secp256k1")
+        if "_COINCURVE_IGNORE_SYSTEM_LIBSECP" in os.environ:
+            return False
+        else:
+            ffi.dlopen("secp256k1")
     except OSError:
         if 'LIB_DIR' in os.environ:
             for path in glob.glob(os.path.join(os.environ['LIB_DIR'], "*secp256k1*")):

--- a/setup_support.py
+++ b/setup_support.py
@@ -71,7 +71,7 @@ def _find_lib():
     from cffi import FFI
     ffi = FFI()
     try:
-        if "_COINCURVE_IGNORE_SYSTEM_LIBSECP" in os.environ:
+        if "COINCURVE_IGNORE_SYSTEM_LIB" in os.environ:
             return False
         else:
             ffi.dlopen("secp256k1")


### PR DESCRIPTION
Related to Joinmarket-Org/joinmarket-clientserver#234
Allow skipping detection of system `libsecp256k1`, forcing use of the bundled library