### PR TITLE
Place libsecp2561 libdir first in library_dir path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -213,7 +213,7 @@ class build_ext(_build_ext):
             )
             self.include_dirs.extend(_build_clib.build_flags['include_dirs'])
 
-            self.library_dirs.append(
+            self.library_dirs.insert(0,
                 os.path.join(_build_clib.build_clib, 'lib'),
             )
             self.library_dirs.extend(_build_clib.build_flags['library_dirs'])

--- a/setup.py
+++ b/setup.py
@@ -213,9 +213,7 @@ class build_ext(_build_ext):
             )
             self.include_dirs.extend(_build_clib.build_flags['include_dirs'])
 
-            self.library_dirs.insert(0,
-                os.path.join(_build_clib.build_clib, 'lib'),
-            )
+            self.library_dirs.insert(0, os.path.join(_build_clib.build_clib, 'lib'))
             self.library_dirs.extend(_build_clib.build_flags['library_dirs'])
 
             self.define = _build_clib.build_flags['define']


### PR DESCRIPTION
This fixes an issue reported by a Gentoo user.  At the point of linking `libsecp256k1`, if the library is installed system-wide on the host, the linker will first consider the `/usr/lib` path when searching for `-lsecp256k1`, causing coincurve's `_libsecp256k1.so` to be dynamically linked to the system's library :

```
$ ldd lib/python2.7/site-packages/coincurve-9.0.0-py2.7-linux-x86_64.egg/coincurve/_libsecp256k1.so
        linux-vdso.so.1 (0x00007fffafb61000)
        libsecp256k1.so.0 => /usr/lib64/libsecp256k1.so.0 (0x00007f0887d45000)
        libpython2.7.so.1.0 => /usr/lib64/libpython2.7.so.1.0 (0x00007f088796e000)
        libpthread.so.0 => /lib64/libpthread.so.0 (0x00007f088774e000)
        libc.so.6 => /lib64/libc.so.6 (0x00007f0887386000)
        libgmp.so.10 => /usr/lib64/libgmp.so.10 (0x00007f088710f000)
        libdl.so.2 => /lib64/libdl.so.2 (0x00007f0886f0b000)
        libutil.so.1 => /lib64/libutil.so.1 (0x00007f0886d08000)
        libm.so.6 => /lib64/libm.so.6 (0x00007f0886970000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f0888176000)
```

This then causes issues e.g. when the system-wide library doesn't contain the ecdh or recovery modules :

```
$ nm lib/python2.7/site-packages/coincurve-9.0.0-py2.7-linux-x86_64.egg/coincurve/_libsecp256k1.so | grep secp256k1_ecdh
00000000000059d9 t _cffi_d_secp256k1_ecdh
0000000000005a0b t _cffi_f_secp256k1_ecdh
                 U secp256k1_ecdh
```

```
$ objdump -T /usr/lib/libsecp256k1.so.0.0.0 | grep secp256k1_ecdh
# (no match)
```

```
Python 2.7.15 (default, Oct  2 2018, 23:50:52)
[GCC 7.3.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import coincurve
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/chaum/joinmarket-clientserver/jmvenv/lib/python2.7/site-packages/coincurve-9.0.0-py2.7-linux-x86_64.egg/coincurve/__init__.py", line 1, in <module>
    from coincurve.context import GLOBAL_CONTEXT, Context
  File "/home/chaum/joinmarket-clientserver/jmvenv/lib/python2.7/site-packages/coincurve-9.0.0-py2.7-linux-x86_64.egg/coincurve/context.py", line 4, in <module>
    from coincurve.flags import CONTEXT_ALL, CONTEXT_FLAGS
  File "/home/chaum/joinmarket-clientserver/jmvenv/lib/python2.7/site-packages/coincurve-9.0.0-py2.7-linux-x86_64.egg/coincurve/flags.py", line 1, in <module>
    from ._libsecp256k1 import lib
ImportError: /home/chaum/joinmarket-clientserver/jmvenv/lib/python2.7/site-packages/coincurve-9.0.0-py2.7-linux-x86_64.egg/coincurve/_libsecp256k1.so: undefined symbol: secp256k1_ecdh
```

This change fixes this issue by put coincurve's build dir first in the library search path, so the correct library is used when linking.