### PR TITLE
Documentatin of ECDH result 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -168,7 +168,7 @@ All instances have a ``public_key`` of type ``coincurve.PublicKey``
 ``ecdh(public_key)``
 
 Computes a Diffie-Hellman secret in constant time. **Note:** This prevents malleability by returning
-``sha256(compressed_key)`` instead of the ``x`` coordinate directly. See `<https://github.com/ofek/coincurve/issues/9>`_.
+``sha256(compressed_public_key)`` instead of the ``x`` coordinate directly. See `<https://github.com/ofek/coincurve/issues/9>`_.
 
 * Parameters:
 

--- a/README.rst
+++ b/README.rst
@@ -168,7 +168,7 @@ All instances have a ``public_key`` of type ``coincurve.PublicKey``
 ``ecdh(public_key)``
 
 Computes a Diffie-Hellman secret in constant time. **Note:** This prevents malleability by returning
-``sha256(x)`` instead of the ``x`` coordinate directly. See `<https://github.com/ofek/coincurve/issues/9>`_.
+``sha256(0x1 or 0x2 | x)`` instead of the ``x`` coordinate directly. See `<https://github.com/ofek/coincurve/issues/9>`_.
 
 * Parameters:
 

--- a/README.rst
+++ b/README.rst
@@ -168,7 +168,7 @@ All instances have a ``public_key`` of type ``coincurve.PublicKey``
 ``ecdh(public_key)``
 
 Computes a Diffie-Hellman secret in constant time. **Note:** This prevents malleability by returning
-``sha256(0x1 or 0x2 | x)`` instead of the ``x`` coordinate directly. See `<https://github.com/ofek/coincurve/issues/9>`_.
+``sha256(compressed_key)`` instead of the ``x`` coordinate directly. See `<https://github.com/ofek/coincurve/issues/9>`_.
 
 * Parameters:
 


### PR DESCRIPTION
Hi,

I've found that ECDH doesn't return `sha256(x)` but a special case of `sha256(compressed_key)` where `compressed_key` is the `x` coordinate prefixed with `0x01` or `0x02` (and not `0x02` or `0x03` as usual.)
See the [C library](https://github.com/bitcoin-core/secp256k1/blob/master/src/modules/ecdh/main_impl.h#L13-L24).
