### PR TITLE
Fix warning in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -268,14 +268,14 @@ setup(
     distclass=Distribution,
     zip_safe=False,
 
-    keywords=(
+    keywords=[
         'secp256k1',
         'crypto',
         'elliptic curves',
         'bitcoin',
         'ethereum',
         'cryptocurrency',
-    ),
+    ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
Running `$ python setup.py build` yielded the following warning `Warning: 'keywords' should be a list, got type 'tuple'`.