### PR TITLE
Resolve issue #57

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -139,6 +139,10 @@ class build_clib(_build_clib):
             if e.errno != errno.EEXIST:
                 raise
 
+        if not os.path.exists(absolute('libsecp256k1')):
+            # library needs to be downloaded
+            self.get_source_files()
+
         if not os.path.exists(absolute('libsecp256k1/configure')):
             # configure script hasn't been generated yet
             autogen = absolute('libsecp256k1/autogen.sh')

--- a/setup_support.py
+++ b/setup_support.py
@@ -69,6 +69,11 @@ def _find_lib():
     ffi = FFI()
     try:
         ffi.dlopen("secp256k1")
+        if os.path.exists('/usr/include/secp256k1_ecdh.h'):
+            return True
+        else:
+            # The system library lacks the ecdh module
+            return False
     except OSError:
         if 'LIB_DIR' in os.environ:
             for path in glob.glob(os.path.join(os.environ['LIB_DIR'], "*secp256k1*")):


### PR DESCRIPTION
This resolves issue #57 

It adds a check for `/usr/include/secp256k1_ecdh.h`, if the header is not present then the system library is not used. I also discovered that `setup.py` doesn't necessarily fetch the sources for libsecp256k1 before building the clib, so I also added a check to ensure they were present before starting a build.