### PR TITLE
CI fixups

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
 coverage
-pytest==7.1
+pytest
 pytest-benchmark

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
 coverage
-pytest
+pytest==7.1
 pytest-benchmark

--- a/tox.ini
+++ b/tox.ini
@@ -70,19 +70,19 @@ setenv =
     ; See https://reproducible-builds.org/specs/source-date-epoch/
     SOURCE_DATE_EPOCH=1580601600
 deps =
-    mkdocs~=1.4.1
+    mkdocs~=1.3.1
     ; theme
-    mkdocs-material~=7.3.1
+    mkdocs-material~=8.3.9
     ; plugins
-    mkdocs-minify-plugin~=0.4.1
-    mkdocs-git-revision-date-localized-plugin~=0.10.0
-    mkdocstrings~=0.16.2
+    mkdocs-minify-plugin~=0.5.0
+    mkdocs-git-revision-date-localized-plugin~=1.1.0
+    mkdocstrings~=0.18.1
     ; Extensions
-    pymdown-extensions~=9.0
+    pymdown-extensions~=9.5.0
     mkdocs-material-extensions~=1.0.3
     mkpatcher~=1.0.2
     ; Necessary for syntax highlighting in code blocks
-    Pygments~=2.10.0
+    Pygments~=2.12.0
 commands =
     python -m mkdocs {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -70,7 +70,7 @@ setenv =
     ; See https://reproducible-builds.org/specs/source-date-epoch/
     SOURCE_DATE_EPOCH=1580601600
 deps =
-    mkdocs~=1.2.2
+    mkdocs~=1.4.1
     ; theme
     mkdocs-material~=7.3.1
     ; plugins


### PR DESCRIPTION
Some tweaks to make CI green. This is just temporary hacks (pinning dependencies) and should eventually be revisited by someone with more knowledge of the test suite and CI config.