### PR TITLE
(fix) uninstalling to prevent 'install' to fail

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -193,6 +193,7 @@ class build_clib(_build_clib):
         if 'COINCURVE_CROSS_HOST' in os.environ:
             cmd.append('--host={}'.format(os.environ['COINCURVE_CROSS_HOST']))
 
+        subprocess.check_call([MAKE, 'uninstall'], cwd=build_temp)
         log.debug('Running configure: {}'.format(' '.join(cmd)))
         subprocess.check_call(cmd, cwd=build_temp)
 


### PR DESCRIPTION
It seems that `install` will fail when ran a second time. This seems to be an issue when trying to build a conda-recipe for this project
There's possibly a more elegant solution in how the recipe is engineered, which I am still learning