### PR TITLE
Feat/complement binding

### DIFF
--- a/.github/scripts/build-windows-wheels.sh
+++ b/.github/scripts/build-windows-wheels.sh
@@ -17,9 +17,9 @@ mv .hidden ../clean
 
 cd ..
 
-curl -sLO "https://github.com/bitcoin-core/secp256k1/archive/ref/tags/$COINCURVE_UPSTREAM_TAG.tar.gz"
-tar -xzf "$COINCURVE_UPSTREAM_TAG.tar.gz"
-mv "secp256k1-$COINCURVE_UPSTREAM_TAG" secp256k1
+curl -sLO "https://github.com/bitcoin-core/secp256k1/archive/$COINCURVE_UPSTREAM_REF.tar.gz"
+tar -xzf "$COINCURVE_UPSTREAM_REF.tar.gz"
+mv "secp256k1-$COINCURVE_UPSTREAM_REF" secp256k1
 
 mv secp256k1 64bit
 cp 64bit 32bit -R

--- a/.github/scripts/build-windows-wheels.sh
+++ b/.github/scripts/build-windows-wheels.sh
@@ -17,9 +17,9 @@ mv .hidden ../clean
 
 cd ..
 
-curl -sLO "https://github.com/bitcoin-core/secp256k1/archive/$COINCURVE_UPSTREAM_REF.tar.gz"
-tar -xzf "$COINCURVE_UPSTREAM_REF.tar.gz"
-mv "secp256k1-$COINCURVE_UPSTREAM_REF" secp256k1
+curl -sLO "https://github.com/bitcoin-core/secp256k1/archive/ref/tags/$COINCURVE_UPSTREAM_TAG.tar.gz"
+tar -xzf "$COINCURVE_UPSTREAM_TAG.tar.gz"
+mv "secp256k1-$COINCURVE_UPSTREAM_TAG" secp256k1
 
 mv secp256k1 64bit
 cp 64bit 32bit -R

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Build documentation
       run: tox -e docs-ci -- build
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: documentation
         path: site
@@ -45,7 +45,7 @@ jobs:
     - build
 
     steps:
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: documentation
         path: site

--- a/_cffi_build/build.py
+++ b/_cffi_build/build.py
@@ -26,7 +26,9 @@ def _mk_ffi(sources, name='_libsecp256k1', **kwargs):
 modules = [
     Source('secp256k1.h', '#include <secp256k1.h>'),
     Source('secp256k1_ecdh.h', '#include <secp256k1_ecdh.h>'),
+    # Source('secp256k1_ellswift.h', '#include <secp256k1_ellswift.h>'),
     Source('secp256k1_extrakeys.h', '#include <secp256k1_extrakeys.h>'),
+    Source('secp256k1_preallocated.h', '#include <secp256k1_preallocated.h>'),
     Source('secp256k1_recovery.h', '#include <secp256k1_recovery.h>'),
     Source('secp256k1_schnorrsig.h', '#include <secp256k1_schnorrsig.h>'),
 ]

--- a/_cffi_build/build.py
+++ b/_cffi_build/build.py
@@ -28,7 +28,6 @@ modules = [
     Source('secp256k1_ecdh.h', '#include <secp256k1_ecdh.h>'),
     Source('secp256k1_extrakeys.h', '#include <secp256k1_extrakeys.h>'),
     Source('secp256k1_recovery.h', '#include <secp256k1_recovery.h>'),
-    Source('secp256k1_preallocated.h', '#include <secp256k1_preallocated.h>'),
     Source('secp256k1_schnorrsig.h', '#include <secp256k1_schnorrsig.h>'),
 ]
 

--- a/_cffi_build/build.py
+++ b/_cffi_build/build.py
@@ -28,6 +28,7 @@ modules = [
     Source('secp256k1_ecdh.h', '#include <secp256k1_ecdh.h>'),
     Source('secp256k1_extrakeys.h', '#include <secp256k1_extrakeys.h>'),
     Source('secp256k1_recovery.h', '#include <secp256k1_recovery.h>'),
+    Source('secp256k1_preallocated.h', '#include <secp256k1_preallocated.h>'),
     Source('secp256k1_schnorrsig.h', '#include <secp256k1_schnorrsig.h>'),
 ]
 

--- a/_cffi_build/secp256k1.h
+++ b/_cffi_build/secp256k1.h
@@ -1,4 +1,5 @@
 typedef struct secp256k1_context_struct secp256k1_context;
+
 typedef struct secp256k1_scratch_space_struct secp256k1_scratch_space;
 
 typedef struct {
@@ -42,6 +43,10 @@ typedef int (*secp256k1_nonce_function)(
 #define SECP256K1_TAG_PUBKEY_HYBRID_EVEN ...
 #define SECP256K1_TAG_PUBKEY_HYBRID_ODD ...
 
+const secp256k1_context *secp256k1_context_static;
+
+const secp256k1_context *secp256k1_context_no_precomp;
+
 void secp256k1_selftest(void);
 
 secp256k1_context* secp256k1_context_create(
@@ -73,6 +78,11 @@ secp256k1_scratch_space* secp256k1_scratch_space_create(
     size_t size
 );
 
+void secp256k1_scratch_space_destroy(
+    const secp256k1_context *ctx,
+    secp256k1_scratch_space *scratch
+);
+
 int secp256k1_ec_pubkey_parse(
     const secp256k1_context* ctx,
     secp256k1_pubkey* pubkey,
@@ -86,6 +96,12 @@ int secp256k1_ec_pubkey_serialize(
     size_t *outputlen,
     const secp256k1_pubkey* pubkey,
     unsigned int flags
+);
+
+int secp256k1_ec_pubkey_cmp(
+    const secp256k1_context *ctx,
+    const secp256k1_pubkey *pubkey1,
+    const secp256k1_pubkey *pubkey2
 );
 
 int secp256k1_ecdsa_signature_parse_compact(
@@ -127,9 +143,9 @@ int secp256k1_ecdsa_signature_normalize(
     const secp256k1_ecdsa_signature *sigin
 );
 
-extern const secp256k1_nonce_function secp256k1_nonce_function_rfc6979;
+const secp256k1_nonce_function secp256k1_nonce_function_rfc6979;
 
-extern const secp256k1_nonce_function secp256k1_nonce_function_default;
+const secp256k1_nonce_function secp256k1_nonce_function_default;
 
 int secp256k1_ecdsa_sign(
     const secp256k1_context* ctx,
@@ -151,16 +167,43 @@ int secp256k1_ec_pubkey_create(
     const unsigned char *seckey
 );
 
+int secp256k1_ec_seckey_negate(
+    const secp256k1_context *ctx,
+    unsigned char *seckey
+);
+
+int secp256k1_ec_privkey_negate(
+    const secp256k1_context *ctx,
+    unsigned char *seckey
+);
+
+int secp256k1_ec_seckey_tweak_add(
+    const secp256k1_context *ctx,
+    unsigned char *seckey,
+    const unsigned char *tweak32
+);
+
 int secp256k1_ec_privkey_tweak_add(
     const secp256k1_context* ctx,
     unsigned char *seckey,
     const unsigned char *tweak
 );
 
+int secp256k1_ec_pubkey_negate(
+    const secp256k1_context *ctx,
+    secp256k1_pubkey *pubkey
+);
+
 int secp256k1_ec_pubkey_tweak_add(
     const secp256k1_context* ctx,
     secp256k1_pubkey *pubkey,
     const unsigned char *tweak
+);
+
+int secp256k1_ec_seckey_tweak_mul(
+    const secp256k1_context *ctx,
+    unsigned char *seckey,
+    const unsigned char *tweak32
 );
 
 int secp256k1_ec_privkey_tweak_mul(
@@ -185,4 +228,13 @@ int secp256k1_ec_pubkey_combine(
     secp256k1_pubkey *out,
     const secp256k1_pubkey * const * ins,
     size_t n
+);
+
+int secp256k1_tagged_sha256(
+    const secp256k1_context *ctx,
+    unsigned char *hash32,
+    const unsigned char *tag,
+    size_t taglen,
+    const unsigned char *msg,
+    size_t msglen
 );

--- a/_cffi_build/secp256k1_ecdh.h
+++ b/_cffi_build/secp256k1_ecdh.h
@@ -1,8 +1,19 @@
+typedef int (*secp256k1_ecdh_hash_function)(
+  unsigned char *output,
+  const unsigned char *x32,
+  const unsigned char *y32,
+  void *data
+);
+
+const secp256k1_ecdh_hash_function secp256k1_ecdh_hash_function_sha256;
+
+const secp256k1_ecdh_hash_function secp256k1_ecdh_hash_function_default;
+
 int secp256k1_ecdh(
   const secp256k1_context* ctx,
   unsigned char *result,
   const secp256k1_pubkey *pubkey,
   const unsigned char *privkey,
-  void *hashfp,
+  secp256k1_ecdh_hash_function hashfp,
   void *data
 );

--- a/_cffi_build/secp256k1_ellswift.h
+++ b/_cffi_build/secp256k1_ellswift.h
@@ -1,0 +1,33 @@
+typedef int (*secp256k1_ellswift_xdh_hash_function)(
+    unsigned char *output,
+    const unsigned char *x32,
+    const unsigned char *ell_a64,
+    const unsigned char *ell_b64,
+    void *data
+);
+
+const secp256k1_ellswift_xdh_hash_function secp256k1_ellswift_xdh_hash_function_prefix;
+
+const secp256k1_ellswift_xdh_hash_function secp256k1_ellswift_xdh_hash_function_bip324;
+
+int secp256k1_ellswift_encode(
+    const secp256k1_context *ctx,
+    unsigned char *ell64,
+    const secp256k1_pubkey *pubkey,
+    const unsigned char *rnd32
+);
+
+int secp256k1_ellswift_decode(
+    const secp256k1_context *ctx,
+    secp256k1_pubkey *pubkey,
+    const unsigned char *ell64
+);
+
+int secp256k1_ellswift_xdh(
+    const secp256k1_context *ctx,
+    unsigned char *result,
+    const secp256k1_pubkey *pubkey,
+    const unsigned char *privkey,
+    secp256k1_ellswift_xdh_hash_function hashfp,
+    void *data
+);

--- a/_cffi_build/secp256k1_preallocated.h
+++ b/_cffi_build/secp256k1_preallocated.h
@@ -1,0 +1,16 @@
+size_t secp256k1_context_preallocated_size(
+    unsigned int flags
+);
+
+secp256k1_context* secp256k1_context_preallocated_create(
+    void* prealloc,
+    unsigned int flags
+);
+
+size_t secp256k1_context_preallocated_clone_size(
+    const secp256k1_context *ctx
+);
+
+void secp256k1_context_preallocated_destroy(
+    secp256k1_context* ctx
+);

--- a/_cffi_build/secp256k1_schnorrsig.h
+++ b/_cffi_build/secp256k1_schnorrsig.h
@@ -9,7 +9,7 @@ typedef int (*secp256k1_nonce_function_hardened)(
     void *data
 );
 
-extern const secp256k1_nonce_function_hardened secp256k1_nonce_function_bip340;
+const secp256k1_nonce_function_hardened secp256k1_nonce_function_bip340;
 
 typedef struct {
     unsigned char magic[4];
@@ -17,7 +17,12 @@ typedef struct {
     void* ndata;
 } secp256k1_schnorrsig_extraparams;
 
-int secp256k1_schnorrsig_sign(
+/**
+* #define SECP256K1_SCHNORRSIG_EXTRAPARAMS_MAGIC ...
+* #define SECP256K1_SCHNORRSIG_EXTRAPARAMS_INIT ...
+**/
+
+int secp256k1_schnorrsig_sign32(
     const secp256k1_context* ctx,
     unsigned char *sig64,
     const unsigned char *msg32,
@@ -25,7 +30,7 @@ int secp256k1_schnorrsig_sign(
     const unsigned char *aux_rand32
 );
 
-int secp256k1_schnorrsig_sign32(
+int secp256k1_schnorrsig_sign(
     const secp256k1_context* ctx,
     unsigned char *sig64,
     const unsigned char *msg32,

--- a/coincurve/keys.py
+++ b/coincurve/keys.py
@@ -159,7 +159,7 @@ class PrivateKey:
 
         secret = ffi.new('unsigned char [32]', self.secret)
 
-        success = lib.secp256k1_ec_privkey_tweak_add(self.context.ctx, secret, scalar)
+        success = lib.secp256k1_ec_seckey_tweak_add(self.context.ctx, secret, scalar)
 
         if not success:
             raise ValueError('The tweak was out of range, or the resulting private key is invalid.')
@@ -186,7 +186,7 @@ class PrivateKey:
 
         secret = ffi.new('unsigned char [32]', self.secret)
 
-        lib.secp256k1_ec_privkey_tweak_mul(self.context.ctx, secret, scalar)
+        lib.secp256k1_ec_seckey_tweak_mul(self.context.ctx, secret, scalar)
 
         secret = bytes(ffi.buffer(secret, 32))
 

--- a/setup.py
+++ b/setup.py
@@ -58,21 +58,19 @@ def download_library(command):
         command.announce('downloading libsecp256k1 source code', level=log.INFO)
         try:
             import requests
-            try:
-                r = requests.get(LIB_TARBALL_URL, stream=True, timeout=10)
-                status_code = r.status_code
-                if status_code == 200:
-                    content = BytesIO(r.raw.read())
-                    content.seek(0)
-                    with tarfile.open(fileobj=content) as tf:
-                        dirname = tf.getnames()[0].partition('/')[0]
-                        tf.extractall()
-                    shutil.move(dirname, libdir)
-                else:
-                    raise SystemExit('Unable to download secp256k1 library: HTTP-Status: %d', status_code)
-            except requests.exceptions.RequestException as e:
-                raise SystemExit('Unable to download secp256k1 library: %s', str(e))
-        except ImportError as e:
+
+            r = requests.get(LIB_TARBALL_URL, stream=True)
+            status_code = r.status_code
+            if status_code == 200:
+                content = BytesIO(r.raw.read())
+                content.seek(0)
+                with tarfile.open(fileobj=content) as tf:
+                    dirname = tf.getnames()[0].partition('/')[0]
+                    tf.extractall()
+                shutil.move(dirname, libdir)
+            else:
+                raise SystemExit('Unable to download secp256k1 library: HTTP-Status: %d', status_code)
+        except requests.exceptions.RequestException as e:
             raise SystemExit('Unable to download secp256k1 library: %s', str(e))
 
 class egg_info(_egg_info):

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ def download_library(command):
         try:
             import requests
 
-            r = requests.get(LIB_TARBALL_URL, stream=True)
+            r = requests.get(LIB_TARBALL_URL, stream=True, timeout=10)
             status_code = r.status_code
             if status_code == 200:
                 content = BytesIO(r.raw.read())

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ deps =
     black>=21.12b0
     ruff
 commands =
-    ruff .
+    ruff . --exclude ./libsecp256k1/tools/tests_wycheproof_generate.py
     black --check --diff .
 
 [testenv:fmt]
@@ -54,7 +54,7 @@ commands =
 [testenv:typing]
 skip_install = true
 deps =
-    mypy==0.790
+    mypy>=0.790
 commands =
     mypy coincurve
 

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ skip_install = true
 deps = {[testenv:lint]deps}
 commands =
     black .
-    ruff --fix .
+    ruff --fix . --exclude ./libsecp256k1/tools/tests_wycheproof_generate.py
     {[testenv:lint]commands}
 
 [testenv:typing]


### PR DESCRIPTION
Proposing a few more updates for your consideration:
   - `secp256k1` seems to be preparing support for EllSwift (no idea as to what that is)
   - At my end, `tox` fails on mypy version and some print statements
   - Replaced use of deprecated functions
