### PR TITLE
(dbg) add test for flags.py

### DIFF
--- a/.github/scripts/build-windows-wheels.sh
+++ b/.github/scripts/build-windows-wheels.sh
@@ -30,6 +30,7 @@ build_dll x86_64-w64-mingw32
 mv .libs/libsecp256k1-?.dll ../clean/coincurve/libsecp256k1.dll
 cd ../clean
 python setup.py bdist_wheel --plat-name=win_amd64
+python -m pytest
 rm coincurve/libsecp256k1.dll
 
 cd ../32bit
@@ -38,6 +39,7 @@ build_dll i686-w64-mingw32
 mv .libs/libsecp256k1-?.dll ../clean/coincurve/libsecp256k1.dll
 cd ../clean
 python setup.py bdist_wheel --plat-name=win32
+python -m pytest
 
 mv dist/* ../coincurve/dist/
 cd ../coincurve

--- a/coincurve/keys.py
+++ b/coincurve/keys.py
@@ -407,7 +407,7 @@ class PublicKey:
 
         return PublicKey(public_key, context)
 
-    def format(self, compressed: bool = True) -> bytes:  # noqa: A003
+    def format(self, compressed: bool = True) -> bytes:
         """
         Format the public key.
 
@@ -579,7 +579,7 @@ class PublicKeyXOnly:
 
         return cls(xonly_pubkey, parity=not not pk_parity[0], context=context)
 
-    def format(self) -> bytes:  # noqa: A003
+    def format(self) -> bytes:
         """Serialize the public key.
 
         :return: The public key serialized as 32 bytes.

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -1,93 +1,17 @@
-import pytest
 from coincurve.flags import (
+    CONTEXT_ALL,
+    CONTEXT_FLAGS,
+    CONTEXT_NONE,
     CONTEXT_SIGN,
     CONTEXT_VERIFY,
-    CONTEXT_ALL,
-    CONTEXT_NONE,
-    CONTEXT_FLAGS,
     EC_COMPRESSED,
     EC_UNCOMPRESSED,
 )
 
 
-# Test constants for correctness
-@pytest.mark.parametrize(
-    "constant, expected_value",
-    [
-        ("CONTEXT_SIGN", CONTEXT_SIGN),
-        ("CONTEXT_VERIFY", CONTEXT_VERIFY),
-        ("CONTEXT_ALL", CONTEXT_ALL),
-        ("CONTEXT_NONE", CONTEXT_NONE),
-        ("EC_COMPRESSED", EC_COMPRESSED),
-        ("EC_UNCOMPRESSED", EC_UNCOMPRESSED),
-    ],
-    ids=[
-        "test_context_sign",
-        "test_context_verify",
-        "test_context_all",
-        "test_context_none",
-        "test_ec_compressed",
-        "test_ec_uncompressed",
-    ]
-)
-def test_constants(constant, expected_value):
-    # Act
-    actual_value = eval(constant)
-
-    # Assert
-    assert actual_value == expected_value, f"{constant} does not match the expected value"
-
-
-# Test CONTEXT_FLAGS for correctness
-@pytest.mark.parametrize(
-    "flag, expected_in_flags",
-    [
-        (CONTEXT_SIGN, True),
-        (CONTEXT_VERIFY, True),
-        (CONTEXT_ALL, True),
-        (CONTEXT_NONE, True),
-        (99999, False),  # Assuming 99999 is not a valid context flag
-    ],
-    ids=[
-        "test_context_flags_sign",
-        "test_context_flags_verify",
-        "test_context_flags_all",
-        "test_context_flags_none",
-        "test_context_flags_invalid",
-    ]
-)
-def test_context_flags(flag, expected_in_flags):
-    # Act
-    result = flag in CONTEXT_FLAGS
-
-    # Assert
-    assert result == expected_in_flags, f"Flag {flag} presence in CONTEXT_FLAGS is not as expected"
-
-
-# Test bitwise operations for CONTEXT_ALL
-@pytest.mark.parametrize(
-    "operation, expected_result",
-    [
-        ("CONTEXT_SIGN | CONTEXT_VERIFY", CONTEXT_ALL),
-        ("CONTEXT_ALL & CONTEXT_SIGN", CONTEXT_SIGN),
-        ("CONTEXT_ALL & CONTEXT_VERIFY", CONTEXT_VERIFY),
-        ("CONTEXT_VERIFY ^ CONTEXT_SIGN", CONTEXT_ALL - 1),
-        ("CONTEXT_SIGN ^ CONTEXT_VERIFY", CONTEXT_ALL - 1),
-    ],
-    ids=[
-        "test_bitwise_or",
-        "test_bitwise_and_sign",
-        "test_bitwise_and_verify",
-        "test_bitwise_xor_verify",
-        "test_bitwise_xor_sign",
-    ]
-)
-def test_bitwise_operations(operation, expected_result):
-    # Act
-    actual_result = eval(operation)
-
-    # Assert
-    assert actual_result == expected_result, f"Bitwise operation {operation} did not yield the expected result"
+def test_context_flags():
+    expected_flags = {CONTEXT_SIGN, CONTEXT_VERIFY, CONTEXT_ALL, CONTEXT_NONE}
+    assert CONTEXT_FLAGS == expected_flags
 
 
 def test_context_sign():

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -1,0 +1,114 @@
+import pytest
+from coincurve.flags import (
+    CONTEXT_SIGN,
+    CONTEXT_VERIFY,
+    CONTEXT_ALL,
+    CONTEXT_NONE,
+    CONTEXT_FLAGS,
+    EC_COMPRESSED,
+    EC_UNCOMPRESSED,
+)
+
+
+# Test constants for correctness
+@pytest.mark.parametrize(
+    "constant, expected_value",
+    [
+        ("CONTEXT_SIGN", CONTEXT_SIGN),
+        ("CONTEXT_VERIFY", CONTEXT_VERIFY),
+        ("CONTEXT_ALL", CONTEXT_ALL),
+        ("CONTEXT_NONE", CONTEXT_NONE),
+        ("EC_COMPRESSED", EC_COMPRESSED),
+        ("EC_UNCOMPRESSED", EC_UNCOMPRESSED),
+    ],
+    ids=[
+        "test_context_sign",
+        "test_context_verify",
+        "test_context_all",
+        "test_context_none",
+        "test_ec_compressed",
+        "test_ec_uncompressed",
+    ]
+)
+def test_constants(constant, expected_value):
+    # Act
+    actual_value = eval(constant)
+
+    # Assert
+    assert actual_value == expected_value, f"{constant} does not match the expected value"
+
+
+# Test CONTEXT_FLAGS for correctness
+@pytest.mark.parametrize(
+    "flag, expected_in_flags",
+    [
+        (CONTEXT_SIGN, True),
+        (CONTEXT_VERIFY, True),
+        (CONTEXT_ALL, True),
+        (CONTEXT_NONE, True),
+        (99999, False),  # Assuming 99999 is not a valid context flag
+    ],
+    ids=[
+        "test_context_flags_sign",
+        "test_context_flags_verify",
+        "test_context_flags_all",
+        "test_context_flags_none",
+        "test_context_flags_invalid",
+    ]
+)
+def test_context_flags(flag, expected_in_flags):
+    # Act
+    result = flag in CONTEXT_FLAGS
+
+    # Assert
+    assert result == expected_in_flags, f"Flag {flag} presence in CONTEXT_FLAGS is not as expected"
+
+
+# Test bitwise operations for CONTEXT_ALL
+@pytest.mark.parametrize(
+    "operation, expected_result",
+    [
+        ("CONTEXT_SIGN | CONTEXT_VERIFY", CONTEXT_ALL),
+        ("CONTEXT_ALL & CONTEXT_SIGN", CONTEXT_SIGN),
+        ("CONTEXT_ALL & CONTEXT_VERIFY", CONTEXT_VERIFY),
+        ("CONTEXT_VERIFY ^ CONTEXT_SIGN", CONTEXT_ALL - 1),
+        ("CONTEXT_SIGN ^ CONTEXT_VERIFY", CONTEXT_ALL - 1),
+    ],
+    ids=[
+        "test_bitwise_or",
+        "test_bitwise_and_sign",
+        "test_bitwise_and_verify",
+        "test_bitwise_xor_verify",
+        "test_bitwise_xor_sign",
+    ]
+)
+def test_bitwise_operations(operation, expected_result):
+    # Act
+    actual_result = eval(operation)
+
+    # Assert
+    assert actual_result == expected_result, f"Bitwise operation {operation} did not yield the expected result"
+
+
+def test_context_sign():
+    assert CONTEXT_SIGN == (1 << 0) | (1 << 9)
+
+
+def test_context_verify():
+    assert CONTEXT_VERIFY == (1 << 0) | (1 << 8)
+
+
+def test_context_all():
+    assert CONTEXT_ALL == CONTEXT_SIGN | CONTEXT_VERIFY
+
+
+def test_context_none():
+    assert CONTEXT_NONE == (1 << 0)
+
+
+def test_ec_compressed():
+    assert EC_COMPRESSED == (1 << 1) | (1 << 8)
+
+
+def test_ec_uncompressed():
+    assert EC_UNCOMPRESSED == (1 << 1)


### PR DESCRIPTION
Trying to figure out why the build failed on windows.

CONTEXT_SIGN and CONTEXT_VERIFY are actually deprecated in SECP256K1 and not used in coincurve. Could it bee that CFFI under windows do not include them in the _libsecp256k1.dll?

This test should trigger the fail in our workflow