### PR TITLE
Resolves app-mode install missing cffi error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,47 +2,6 @@
 requires = ["setuptools>=61", "cffi>=1.3.0", "requests"]
 build-backend = "setuptools.build_meta"
 
-[project]
-name = "coincurve"
-version = "19.0.0"
-authors = [
-  { name="Ofek Lev", email="oss@ofek.dev" },
-]
-description = "Cross-platform Python CFFI bindings for libsecp256k1"
-license = { file="LICENSE-MIT" }
-keywords = ["secp256k1", "crypto", "elliptic curves", "bitcoin", "ethereum", "cryptocurrency"]
-readme = "README.md"
-requires-python = ">=3.8"
-dependencies = [
-    "asn1crypto",
-    "cffi>=1.3.0"
-]
-classifiers = [
-    'Development Status :: 5 - Production/Stable',
-    'Intended Audience :: Developers',
-    'License :: OSI Approved :: MIT License',
-    'License :: OSI Approved :: Apache Software License',
-    'Natural Language :: English',
-    'Operating System :: OS Independent',
-    'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.8',
-    'Programming Language :: Python :: 3.9',
-    'Programming Language :: Python :: 3.10',
-    'Programming Language :: Python :: 3.11',
-    'Programming Language :: Python :: 3.12',
-    'Programming Language :: Python :: Implementation :: CPython',
-    'Programming Language :: Python :: Implementation :: PyPy',
-    'Topic :: Software Development :: Libraries',
-    'Topic :: Security :: Cryptography',
-]
-
-[project.urls]
-"Homepage" = "https://github.com/ofek/coincurve"
-"Bug Tracker" = "https://github.com/ofek/coincurve/issues"
-"Documentation" = "https://ofek.dev/coincurve/"
-"Issues" = "https://github.com/ofek/coincurve/issues"
-"Source" = "https://github.com/ofek/coincurve"
-
 [tool.pytest.ini_options]
 addopts = [
     "--import-mode=importlib",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,56 @@
+[metadata]
+name = coincurve
+version = 19.0.0
+authors = Ofek Lev
+author_email=oss@ofek.dev
+description = Cross-platform Python CFFI bindings for libsecp256k1
+long_description = file: README.md, LICENSE-MIT, LICENSE-APACHE
+url = https://ofek.dev/coincurve
+project_urls =
+    Documentation = https://ofek.dev/coincurve
+    Issues = https://github.com/ofek/coincurve/issues
+license_files =
+    LICENSE-MIT
+    LICENSE-APACHE
+license = MIT OR Apache-2.0
+platforms = any
+keywords =
+    secp256k1
+    crypto
+    elliptic curves
+    bitcoin
+    ethereum
+    cryptocurrency
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Intended Audience :: Developers
+    License :: OSI Approved :: MIT License
+    License :: OSI Approved :: Apache Software License
+    Natural Language :: English
+    Operating System :: OS Independent
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: Implementation :: CPython
+    Programming Language :: Python :: Implementation :: PyPy
+    Topic :: Software Development :: Libraries
+    Topic :: Security :: Cryptography
+
+[options]
+packages = find:
+include_package_data = True
+python_requires = >=3.8
+install_requires =
+    asn1crypto
+    cffi
+zip_safe = False
+
+[options.packages.find]
+exclude =
+    _cffi_build
+    _cffi_build.*
+    libsecp256k1
+    tests

--- a/setup.py
+++ b/setup.py
@@ -210,6 +210,7 @@ class build_clib(_build_clib):
 
         subprocess.check_call([MAKE], cwd=build_temp)  # noqa S603
         subprocess.check_call([MAKE, 'check'], cwd=build_temp)  # noqa S603
+        subprocess.check_call([MAKE, 'uninstall'], cwd=build_temp)  # noqa S603
         subprocess.check_call([MAKE, 'install'], cwd=build_temp)  # noqa S603
 
         self.build_flags['include_dirs'].extend(build_flags('libsecp256k1', 'I', build_temp))

--- a/setup.py
+++ b/setup.py
@@ -318,7 +318,6 @@ else:
 
 
         setup_kwargs = dict(
-            setup_requires=['cffi>=1.3.0', 'requests'],
             ext_package='coincurve',
             cffi_modules=['_cffi_build/build.py:ffi'],
             cmdclass={
@@ -332,13 +331,7 @@ else:
         )
 
 setup(
-    name='coincurve',
-    version='19.0.0',
-
-    packages=find_packages(exclude=('_cffi_build', '_cffi_build.*', 'libsecp256k1', 'tests')),
     package_data=package_data,
-
     distclass=Distribution,
-    zip_safe=False,
     **setup_kwargs
 )

--- a/setup.py
+++ b/setup.py
@@ -4,20 +4,20 @@ import os.path
 import platform
 import shutil
 import subprocess
+import sys
 import tarfile
 from io import BytesIO
-import sys
 
-from setuptools import Distribution as _Distribution, setup, find_packages, __version__ as setuptools_version
+from setuptools import Distribution as _Distribution, setup, __version__ as setuptools_version
 from setuptools._distutils import log
 from setuptools._distutils.errors import DistutilsError
 from setuptools.command.build_clib import build_clib as _build_clib
 from setuptools.command.build_ext import build_ext as _build_ext
-from setuptools.extension import Extension
 from setuptools.command.develop import develop as _develop
 from setuptools.command.dist_info import dist_info as _dist_info
 from setuptools.command.egg_info import egg_info as _egg_info
 from setuptools.command.sdist import sdist as _sdist
+from setuptools.extension import Extension
 
 try:
     from wheel.bdist_wheel import bdist_wheel as _bdist_wheel


### PR DESCRIPTION
Proposes to use `setup.cfg` to iimplement the separation of metadata from `setup.py` as opposed to using `pyproject.toml`
Several discussions reports that `pip install` needs to have `-r pyproject.toml` to parse the requirements. This could be the reason for  https://github.com/ofek/coincurve/issues/143
