### PR TITLE
(feat) refactor tests with fixture

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ env:
   CIBW_ENVIRONMENT_PASS_LINUX: >
     COINCURVE_UPSTREAM_REF
     COINCURVE_IGNORE_SYSTEM_LIB
+  CIBW_TEST_REQUIRES: pytest pytest-benchmark
   CIBW_TEST_COMMAND: >
     python -c
     "from coincurve import PrivateKey;

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,8 @@ env:
     a=PrivateKey();
     b=PrivateKey();
     assert a.ecdh(b.public_key.format())==b.ecdh(a.public_key.format())
-    "
+    " &&
+    python -m pytest {project}
   CIBW_TEST_SKIP: "*-macosx_arm64"
   CIBW_SKIP: >
       pp*

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ def download_library(command):
                     content.seek(0)
                     with tarfile.open(fileobj=content) as tf:
                         dirname = tf.getnames()[0].partition('/')[0]
-                        tf.extractall()
+                        tf.extractall()  # noqa S202
                     shutil.move(dirname, libdir)
                 else:
                     raise SystemExit('Unable to download secp256k1 library: HTTP-Status: %d', status_code)

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ except ImportError:
     _bdist_wheel = None
 
 sys.path.append(os.path.abspath(os.path.dirname(__file__)))
-from setup_support import absolute, build_flags, detect_dll, has_system_lib  # noqa: E402
+from setup_support import absolute, build_flags, detect_dll, has_system_lib
 
 BUILDING_FOR_WINDOWS = detect_dll()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import pytest
+
 PRIVATE_KEY_BYTES = b'\xc2\x8a\x9f\x80s\x8fw\rRx\x03\xa5f\xcfo\xc3\xed\xf6\xce\xa5\x86\xc4\xfcJR#\xa5\xady~\x1a\xc3'
 PRIVATE_KEY_DER = (
     b'0\x81\x84\x02\x01\x000\x10\x06\x07*\x86H\xce=\x02\x01\x06'
@@ -51,3 +53,23 @@ RECOVERABLE_SIGNATURE = (
 
 X_ONLY_PUBKEY = b"Ncx\x00\xf1_'BV\x9ac\x0b\xec)\x0eH\xdf\xebc\xa9\\\x85\x19:\xf9L{B\xe6\x14\xfe\xa8"
 X_ONLY_PUBKEY_INVALID = bytes(32)
+
+
+@pytest.fixture
+def samples():
+    return {
+        'MESSAGE': MESSAGE,
+        'PRIVATE_KEY_BYTES': PRIVATE_KEY_BYTES,
+        'PRIVATE_KEY_DER': PRIVATE_KEY_DER,
+        'PRIVATE_KEY_HEX': PRIVATE_KEY_HEX,
+        'PRIVATE_KEY_NUM': PRIVATE_KEY_NUM,
+        'PRIVATE_KEY_PEM': PRIVATE_KEY_PEM,
+        'PUBLIC_KEY_COMPRESSED': PUBLIC_KEY_COMPRESSED,
+        'PUBLIC_KEY_UNCOMPRESSED': PUBLIC_KEY_UNCOMPRESSED,
+        'PUBLIC_KEY_X': PUBLIC_KEY_X,
+        'PUBLIC_KEY_Y': PUBLIC_KEY_Y,
+        'SIGNATURE': SIGNATURE,
+        'RECOVERABLE_SIGNATURE': RECOVERABLE_SIGNATURE,
+        'X_ONLY_PUBKEY': X_ONLY_PUBKEY,
+        'X_ONLY_PUBKEY_INVALID': X_ONLY_PUBKEY_INVALID,
+    }

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -1,53 +1,60 @@
 from coincurve import PrivateKey, PublicKey, verify_signature
 
-from .samples import MESSAGE, PRIVATE_KEY_BYTES, PUBLIC_KEY_COMPRESSED, SIGNATURE
 
-
-def test_verify_signature_util(benchmark):
-    benchmark(verify_signature, SIGNATURE, MESSAGE, PUBLIC_KEY_COMPRESSED)
+def test_verify_signature_util(benchmark, samples):
+    signature = samples.get('SIGNATURE')
+    message = samples.get('MESSAGE')
+    public_key = samples.get('PUBLIC_KEY_COMPRESSED')
+    benchmark(verify_signature, signature, message, public_key)
 
 
 def test_private_key_new(benchmark):
     benchmark(PrivateKey)
 
 
-def test_private_key_load(benchmark):
-    benchmark(PrivateKey, PRIVATE_KEY_BYTES)
+def test_private_key_load(benchmark, samples):
+    benchmark(PrivateKey, samples.get('PRIVATE_KEY_BYTES'))
 
 
-def test_private_key_sign(benchmark):
-    private_key = PrivateKey(PRIVATE_KEY_BYTES)
-    benchmark(private_key.sign, MESSAGE)
+def test_private_key_sign(benchmark, samples):
+    private_key = PrivateKey(samples.get('PRIVATE_KEY_BYTES'))
+    benchmark(private_key.sign, samples.get('MESSAGE'))
 
 
-def test_private_key_sign_recoverable(benchmark):
-    private_key = PrivateKey(PRIVATE_KEY_BYTES)
-    benchmark(private_key.sign_recoverable, MESSAGE)
+def test_private_key_sign_recoverable(benchmark, samples):
+    private_key = PrivateKey(samples.get('PRIVATE_KEY_BYTES'))
+    benchmark(private_key.sign_recoverable, samples.get('MESSAGE'))
 
 
-def test_private_key_ecdh(benchmark):
-    private_key = PrivateKey(PRIVATE_KEY_BYTES)
-    benchmark(private_key.ecdh, PUBLIC_KEY_COMPRESSED)
+def test_private_key_ecdh(benchmark, samples):
+    private_key = PrivateKey(samples.get('PRIVATE_KEY_BYTES'))
+    benchmark(private_key.ecdh, samples.get('PUBLIC_KEY_COMPRESSED'))
 
 
-def test_public_key_load(benchmark):
-    benchmark(PublicKey, PUBLIC_KEY_COMPRESSED)
+def test_public_key_load(benchmark, samples):
+    benchmark(PublicKey, samples.get('PUBLIC_KEY_COMPRESSED'))
 
 
-def test_public_key_load_from_valid_secret(benchmark):
-    benchmark(PublicKey.from_valid_secret, PRIVATE_KEY_BYTES)
+def test_public_key_load_from_valid_secret(benchmark, samples):
+    benchmark(PublicKey.from_valid_secret, samples.get('PRIVATE_KEY_BYTES'))
 
 
-def test_public_key_format(benchmark):
-    public_key = PublicKey(PUBLIC_KEY_COMPRESSED)
+def test_public_key_format(benchmark, samples):
+    public_key = PublicKey(samples.get('PUBLIC_KEY_COMPRESSED'))
     benchmark(public_key.format)
 
 
-def test_public_key_point(benchmark):
-    public_key = PublicKey(PUBLIC_KEY_COMPRESSED)
+def test_public_key_point(benchmark, samples):
+    public_key = PublicKey(samples.get('PUBLIC_KEY_COMPRESSED'))
     benchmark(public_key.point)
 
 
-def test_public_key_verify(benchmark):
-    public_key = PublicKey(PUBLIC_KEY_COMPRESSED)
-    benchmark(public_key.verify, SIGNATURE, MESSAGE)
+def test_public_key_verify(benchmark, samples):
+    public_key = PublicKey(samples.get('PUBLIC_KEY_COMPRESSED'))
+    benchmark(public_key.verify, samples.get('SIGNATURE'), samples.get('MESSAGE'))
+
+
+if __name__ == '__main__':
+    import pytest
+
+    pytest.main(['-s', __file__])

--- a/tests/test_bench.py
+++ b/tests/test_bench.py
@@ -2,9 +2,9 @@ from coincurve import PrivateKey, PublicKey, verify_signature
 
 
 def test_verify_signature_util(benchmark, samples):
-    signature = samples.get('SIGNATURE')
-    message = samples.get('MESSAGE')
-    public_key = samples.get('PUBLIC_KEY_COMPRESSED')
+    signature = samples['SIGNATURE']
+    message = samples['MESSAGE']
+    public_key = samples['PUBLIC_KEY_COMPRESSED']
     benchmark(verify_signature, signature, message, public_key)
 
 
@@ -13,45 +13,45 @@ def test_private_key_new(benchmark):
 
 
 def test_private_key_load(benchmark, samples):
-    benchmark(PrivateKey, samples.get('PRIVATE_KEY_BYTES'))
+    benchmark(PrivateKey, samples['PRIVATE_KEY_BYTES'])
 
 
 def test_private_key_sign(benchmark, samples):
-    private_key = PrivateKey(samples.get('PRIVATE_KEY_BYTES'))
-    benchmark(private_key.sign, samples.get('MESSAGE'))
+    private_key = PrivateKey(samples['PRIVATE_KEY_BYTES'])
+    benchmark(private_key.sign, samples['MESSAGE'])
 
 
 def test_private_key_sign_recoverable(benchmark, samples):
-    private_key = PrivateKey(samples.get('PRIVATE_KEY_BYTES'))
-    benchmark(private_key.sign_recoverable, samples.get('MESSAGE'))
+    private_key = PrivateKey(samples['PRIVATE_KEY_BYTES'])
+    benchmark(private_key.sign_recoverable, samples['MESSAGE'])
 
 
 def test_private_key_ecdh(benchmark, samples):
-    private_key = PrivateKey(samples.get('PRIVATE_KEY_BYTES'))
-    benchmark(private_key.ecdh, samples.get('PUBLIC_KEY_COMPRESSED'))
+    private_key = PrivateKey(samples['PRIVATE_KEY_BYTES'])
+    benchmark(private_key.ecdh, samples['PUBLIC_KEY_COMPRESSED'])
 
 
 def test_public_key_load(benchmark, samples):
-    benchmark(PublicKey, samples.get('PUBLIC_KEY_COMPRESSED'))
+    benchmark(PublicKey, samples['PUBLIC_KEY_COMPRESSED'])
 
 
 def test_public_key_load_from_valid_secret(benchmark, samples):
-    benchmark(PublicKey.from_valid_secret, samples.get('PRIVATE_KEY_BYTES'))
+    benchmark(PublicKey.from_valid_secret, samples['PRIVATE_KEY_BYTES'])
 
 
 def test_public_key_format(benchmark, samples):
-    public_key = PublicKey(samples.get('PUBLIC_KEY_COMPRESSED'))
+    public_key = PublicKey(samples['PUBLIC_KEY_COMPRESSED'])
     benchmark(public_key.format)
 
 
 def test_public_key_point(benchmark, samples):
-    public_key = PublicKey(samples.get('PUBLIC_KEY_COMPRESSED'))
+    public_key = PublicKey(samples['PUBLIC_KEY_COMPRESSED'])
     benchmark(public_key.point)
 
 
 def test_public_key_verify(benchmark, samples):
-    public_key = PublicKey(samples.get('PUBLIC_KEY_COMPRESSED'))
-    benchmark(public_key.verify, samples.get('SIGNATURE'), samples.get('MESSAGE'))
+    public_key = PublicKey(samples['PUBLIC_KEY_COMPRESSED'])
+    benchmark(public_key.verify, samples['SIGNATURE'], samples['MESSAGE'])
 
 
 if __name__ == '__main__':

--- a/tests/test_ecdsa.py
+++ b/tests/test_ecdsa.py
@@ -1,7 +1,11 @@
+import pytest
+
 from coincurve.ecdsa import cdata_to_der, der_to_cdata
 
-from .samples import SIGNATURE
+
+def test_der(samples):
+    assert cdata_to_der(der_to_cdata(samples.get('SIGNATURE'))) == samples.get('SIGNATURE')
 
 
-def test_der():
-    assert cdata_to_der(der_to_cdata(SIGNATURE)) == SIGNATURE
+if __name__ == '__main__':
+    pytest.main(['-s', __file__])

--- a/tests/test_ecdsa.py
+++ b/tests/test_ecdsa.py
@@ -4,7 +4,7 @@ from coincurve.ecdsa import cdata_to_der, der_to_cdata
 
 
 def test_der(samples):
-    assert cdata_to_der(der_to_cdata(samples.get('SIGNATURE'))) == samples.get('SIGNATURE')
+    assert cdata_to_der(der_to_cdata(samples['SIGNATURE'])) == samples['SIGNATURE']
 
 
 if __name__ == '__main__':

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -18,12 +18,11 @@ n = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
 
 class TestPrivateKey:
     def test_public_key(self, samples):
-        assert PrivateKey(samples.get('PRIVATE_KEY_BYTES')).public_key.format() == samples.get('PUBLIC_KEY_COMPRESSED')
+        assert PrivateKey(samples['PRIVATE_KEY_BYTES']).public_key.format() == samples['PUBLIC_KEY_COMPRESSED']
 
     def test_xonly_pubkey(self, samples):
         assert (
-            PrivateKey(samples.get('PRIVATE_KEY_BYTES')).public_key_xonly.format()
-            == samples.get('PUBLIC_KEY_COMPRESSED')[1:]
+            PrivateKey(samples['PRIVATE_KEY_BYTES']).public_key_xonly.format() == samples['PUBLIC_KEY_COMPRESSED'][1:]
         )
 
     def test_signature_correct(self):
@@ -37,20 +36,20 @@ class TestPrivateKey:
         assert verify_signature(signature, message, public_key.format(compressed=False))
 
     def test_signature_deterministic(self, samples):
-        assert PrivateKey(samples.get('PRIVATE_KEY_BYTES')).sign(samples.get('MESSAGE')) == samples.get('SIGNATURE')
+        assert PrivateKey(samples['PRIVATE_KEY_BYTES']).sign(samples['MESSAGE']) == samples['SIGNATURE']
 
     def test_signature_invalid_hasher(self, samples):
         with pytest.raises(ValueError):
-            PrivateKey().sign(samples.get('MESSAGE'), lambda x: sha512(x).digest())
+            PrivateKey().sign(samples['MESSAGE'], lambda x: sha512(x).digest())
 
     def test_signature_recoverable(self, samples):
-        private_key = PrivateKey(samples.get('PRIVATE_KEY_BYTES'))
+        private_key = PrivateKey(samples['PRIVATE_KEY_BYTES'])
         assert (
             private_key.public_key.format()
             == PublicKey(
                 recover(
-                    samples.get('MESSAGE'),
-                    deserialize_recoverable(private_key.sign_recoverable(samples.get('MESSAGE'))),
+                    samples['MESSAGE'],
+                    deserialize_recoverable(private_key.sign_recoverable(samples['MESSAGE'])),
                 )
             ).format()
         )
@@ -72,28 +71,28 @@ class TestPrivateKey:
         assert private_key.public_key_xonly.verify(sig, message)
 
     def test_to_hex(self, samples):
-        assert PrivateKey(samples.get('PRIVATE_KEY_BYTES')).to_hex() == samples.get('PRIVATE_KEY_HEX')
+        assert PrivateKey(samples['PRIVATE_KEY_BYTES']).to_hex() == samples['PRIVATE_KEY_HEX']
 
     def test_to_int(self, samples):
-        assert PrivateKey(samples.get('PRIVATE_KEY_BYTES')).to_int() == samples.get('PRIVATE_KEY_NUM')
+        assert PrivateKey(samples['PRIVATE_KEY_BYTES']).to_int() == samples['PRIVATE_KEY_NUM']
 
     def test_to_pem(self, samples):
-        assert PrivateKey(samples.get('PRIVATE_KEY_BYTES')).to_pem() == samples.get('PRIVATE_KEY_PEM')
+        assert PrivateKey(samples['PRIVATE_KEY_BYTES']).to_pem() == samples['PRIVATE_KEY_PEM']
 
     def test_to_der(self, samples):
-        assert PrivateKey(samples.get('PRIVATE_KEY_BYTES')).to_der() == samples.get('PRIVATE_KEY_DER')
+        assert PrivateKey(samples['PRIVATE_KEY_BYTES']).to_der() == samples['PRIVATE_KEY_DER']
 
     def test_from_hex(self, samples):
-        assert PrivateKey.from_hex(samples.get('PRIVATE_KEY_HEX')).secret == samples.get('PRIVATE_KEY_BYTES')
+        assert PrivateKey.from_hex(samples['PRIVATE_KEY_HEX']).secret == samples['PRIVATE_KEY_BYTES']
 
     def test_from_int(self, samples):
-        assert PrivateKey.from_int(samples.get('PRIVATE_KEY_NUM')).secret == samples.get('PRIVATE_KEY_BYTES')
+        assert PrivateKey.from_int(samples['PRIVATE_KEY_NUM']).secret == samples['PRIVATE_KEY_BYTES']
 
     def test_from_pem(self, samples):
-        assert PrivateKey.from_pem(samples.get('PRIVATE_KEY_PEM')).secret == samples.get('PRIVATE_KEY_BYTES')
+        assert PrivateKey.from_pem(samples['PRIVATE_KEY_PEM']).secret == samples['PRIVATE_KEY_BYTES']
 
     def test_from_der(self, samples):
-        assert PrivateKey.from_der(samples.get('PRIVATE_KEY_DER')).secret == samples.get('PRIVATE_KEY_BYTES')
+        assert PrivateKey.from_der(samples['PRIVATE_KEY_DER']).secret == samples['PRIVATE_KEY_BYTES']
 
     def test_ecdh(self):
         a = PrivateKey()
@@ -124,38 +123,36 @@ class TestPrivateKey:
 
 class TestPublicKey:
     def test_from_secret(self, samples):
-        assert PublicKey.from_secret(samples.get('PRIVATE_KEY_BYTES')).format() == samples.get('PUBLIC_KEY_COMPRESSED')
+        assert PublicKey.from_secret(samples['PRIVATE_KEY_BYTES']).format() == samples['PUBLIC_KEY_COMPRESSED']
 
     def test_from_point(self, samples):
-        assert PublicKey.from_point(samples.get('PUBLIC_KEY_X'), samples.get('PUBLIC_KEY_Y')).format() == samples.get(
+        assert PublicKey.from_point(samples['PUBLIC_KEY_X'], samples['PUBLIC_KEY_Y']).format() == samples.get(
             'PUBLIC_KEY_COMPRESSED'
         )
 
     def test_from_signature_and_message(self, samples):
         assert (
-            PublicKey.from_secret(samples.get('PRIVATE_KEY_BYTES')).format()
-            == PublicKey.from_signature_and_message(
-                samples.get('RECOVERABLE_SIGNATURE'), samples.get('MESSAGE')
-            ).format()
+            PublicKey.from_secret(samples['PRIVATE_KEY_BYTES']).format()
+            == PublicKey.from_signature_and_message(samples['RECOVERABLE_SIGNATURE'], samples['MESSAGE']).format()
         )
 
     def test_format(self, samples):
-        assert PublicKey(samples.get('PUBLIC_KEY_UNCOMPRESSED')).format(compressed=True) == samples.get(
+        assert PublicKey(samples['PUBLIC_KEY_UNCOMPRESSED']).format(compressed=True) == samples.get(
             'PUBLIC_KEY_COMPRESSED'
         )
-        assert PublicKey(samples.get('PUBLIC_KEY_COMPRESSED')).format(compressed=False) == samples.get(
+        assert PublicKey(samples['PUBLIC_KEY_COMPRESSED']).format(compressed=False) == samples.get(
             'PUBLIC_KEY_UNCOMPRESSED'
         )
 
     def test_point(self, samples):
-        assert PublicKey(samples.get('PUBLIC_KEY_COMPRESSED')).point() == (
-            samples.get('PUBLIC_KEY_X'),
-            samples.get('PUBLIC_KEY_Y'),
+        assert PublicKey(samples['PUBLIC_KEY_COMPRESSED']).point() == (
+            samples['PUBLIC_KEY_X'],
+            samples['PUBLIC_KEY_Y'],
         )
 
     def test_verify(self, samples):
-        public_key = PublicKey(samples.get('PUBLIC_KEY_COMPRESSED'))
-        assert public_key.verify(samples.get('SIGNATURE'), samples.get('MESSAGE'))
+        public_key = PublicKey(samples['PUBLIC_KEY_COMPRESSED'])
+        assert public_key.verify(samples['SIGNATURE'], samples['MESSAGE'])
 
     def test_transform(self):
         x = urandom(32)
@@ -179,17 +176,14 @@ class TestXonlyPubKey:
 
         # Must be an x coordinate for a valid point
         with pytest.raises(ValueError):
-            PublicKeyXOnly(samples.get('X_ONLY_PUBKEY_INVALID'))
+            PublicKeyXOnly(samples['X_ONLY_PUBKEY_INVALID'])
 
     def test_roundtrip(self, samples):
-        assert PublicKeyXOnly(samples.get('X_ONLY_PUBKEY')).format() == samples.get('X_ONLY_PUBKEY')
-        assert (
-            PublicKeyXOnly(samples.get('PUBLIC_KEY_COMPRESSED')[1:]).format()
-            == samples.get('PUBLIC_KEY_COMPRESSED')[1:]
-        )
+        assert PublicKeyXOnly(samples['X_ONLY_PUBKEY']).format() == samples['X_ONLY_PUBKEY']
+        assert PublicKeyXOnly(samples['PUBLIC_KEY_COMPRESSED'][1:]).format() == samples['PUBLIC_KEY_COMPRESSED'][1:]
 
         # Test __eq__
-        assert PublicKeyXOnly(samples.get('X_ONLY_PUBKEY')) == PublicKeyXOnly(samples.get('X_ONLY_PUBKEY'))
+        assert PublicKeyXOnly(samples['X_ONLY_PUBKEY']) == PublicKeyXOnly(samples['X_ONLY_PUBKEY'])
 
     def test_tweak(self):
         # Taken from BIP341 test vectors.

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -7,23 +7,6 @@ from coincurve.ecdsa import deserialize_recoverable, recover
 from coincurve.keys import PrivateKey, PublicKey, PublicKeyXOnly
 from coincurve.utils import bytes_to_int, int_to_bytes_padded, verify_signature
 
-from .samples import (
-    MESSAGE,
-    PRIVATE_KEY_BYTES,
-    PRIVATE_KEY_DER,
-    PRIVATE_KEY_HEX,
-    PRIVATE_KEY_NUM,
-    PRIVATE_KEY_PEM,
-    PUBLIC_KEY_COMPRESSED,
-    PUBLIC_KEY_UNCOMPRESSED,
-    PUBLIC_KEY_X,
-    PUBLIC_KEY_Y,
-    RECOVERABLE_SIGNATURE,
-    SIGNATURE,
-    X_ONLY_PUBKEY,
-    X_ONLY_PUBKEY_INVALID,
-)
-
 G = PublicKey(
     b'\x04y\xbef~\xf9\xdc\xbb\xacU\xa0b\x95\xce\x87\x0b\x07\x02\x9b'
     b'\xfc\xdb-\xce(\xd9Y\xf2\x81[\x16\xf8\x17\x98H:\xdaw&\xa3\xc4e'
@@ -34,11 +17,14 @@ n = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
 
 
 class TestPrivateKey:
-    def test_public_key(self):
-        assert PrivateKey(PRIVATE_KEY_BYTES).public_key.format() == PUBLIC_KEY_COMPRESSED
+    def test_public_key(self, samples):
+        assert PrivateKey(samples.get('PRIVATE_KEY_BYTES')).public_key.format() == samples.get('PUBLIC_KEY_COMPRESSED')
 
-    def test_xonly_pubkey(self):
-        assert PrivateKey(PRIVATE_KEY_BYTES).public_key_xonly.format() == PUBLIC_KEY_COMPRESSED[1:]
+    def test_xonly_pubkey(self, samples):
+        assert (
+            PrivateKey(samples.get('PRIVATE_KEY_BYTES')).public_key_xonly.format()
+            == samples.get('PUBLIC_KEY_COMPRESSED')[1:]
+        )
 
     def test_signature_correct(self):
         private_key = PrivateKey()
@@ -50,18 +36,23 @@ class TestPrivateKey:
         assert verify_signature(signature, message, public_key.format(compressed=True))
         assert verify_signature(signature, message, public_key.format(compressed=False))
 
-    def test_signature_deterministic(self):
-        assert PrivateKey(PRIVATE_KEY_BYTES).sign(MESSAGE) == SIGNATURE
+    def test_signature_deterministic(self, samples):
+        assert PrivateKey(samples.get('PRIVATE_KEY_BYTES')).sign(samples.get('MESSAGE')) == samples.get('SIGNATURE')
 
-    def test_signature_invalid_hasher(self):
+    def test_signature_invalid_hasher(self, samples):
         with pytest.raises(ValueError):
-            PrivateKey().sign(MESSAGE, lambda x: sha512(x).digest())
+            PrivateKey().sign(samples.get('MESSAGE'), lambda x: sha512(x).digest())
 
-    def test_signature_recoverable(self):
-        private_key = PrivateKey(PRIVATE_KEY_BYTES)
+    def test_signature_recoverable(self, samples):
+        private_key = PrivateKey(samples.get('PRIVATE_KEY_BYTES'))
         assert (
             private_key.public_key.format()
-            == PublicKey(recover(MESSAGE, deserialize_recoverable(private_key.sign_recoverable(MESSAGE)))).format()
+            == PublicKey(
+                recover(
+                    samples.get('MESSAGE'),
+                    deserialize_recoverable(private_key.sign_recoverable(samples.get('MESSAGE'))),
+                )
+            ).format()
         )
 
     def test_schnorr_signature(self):
@@ -80,29 +71,29 @@ class TestPrivateKey:
         sig = private_key.sign_schnorr(message)
         assert private_key.public_key_xonly.verify(sig, message)
 
-    def test_to_hex(self):
-        assert PrivateKey(PRIVATE_KEY_BYTES).to_hex() == PRIVATE_KEY_HEX
+    def test_to_hex(self, samples):
+        assert PrivateKey(samples.get('PRIVATE_KEY_BYTES')).to_hex() == samples.get('PRIVATE_KEY_HEX')
 
-    def test_to_int(self):
-        assert PrivateKey(PRIVATE_KEY_BYTES).to_int() == PRIVATE_KEY_NUM
+    def test_to_int(self, samples):
+        assert PrivateKey(samples.get('PRIVATE_KEY_BYTES')).to_int() == samples.get('PRIVATE_KEY_NUM')
 
-    def test_to_pem(self):
-        assert PrivateKey(PRIVATE_KEY_BYTES).to_pem() == PRIVATE_KEY_PEM
+    def test_to_pem(self, samples):
+        assert PrivateKey(samples.get('PRIVATE_KEY_BYTES')).to_pem() == samples.get('PRIVATE_KEY_PEM')
 
-    def test_to_der(self):
-        assert PrivateKey(PRIVATE_KEY_BYTES).to_der() == PRIVATE_KEY_DER
+    def test_to_der(self, samples):
+        assert PrivateKey(samples.get('PRIVATE_KEY_BYTES')).to_der() == samples.get('PRIVATE_KEY_DER')
 
-    def test_from_hex(self):
-        assert PrivateKey.from_hex(PRIVATE_KEY_HEX).secret == PRIVATE_KEY_BYTES
+    def test_from_hex(self, samples):
+        assert PrivateKey.from_hex(samples.get('PRIVATE_KEY_HEX')).secret == samples.get('PRIVATE_KEY_BYTES')
 
-    def test_from_int(self):
-        assert PrivateKey.from_int(PRIVATE_KEY_NUM).secret == PRIVATE_KEY_BYTES
+    def test_from_int(self, samples):
+        assert PrivateKey.from_int(samples.get('PRIVATE_KEY_NUM')).secret == samples.get('PRIVATE_KEY_BYTES')
 
-    def test_from_pem(self):
-        assert PrivateKey.from_pem(PRIVATE_KEY_PEM).secret == PRIVATE_KEY_BYTES
+    def test_from_pem(self, samples):
+        assert PrivateKey.from_pem(samples.get('PRIVATE_KEY_PEM')).secret == samples.get('PRIVATE_KEY_BYTES')
 
-    def test_from_der(self):
-        assert PrivateKey.from_der(PRIVATE_KEY_DER).secret == PRIVATE_KEY_BYTES
+    def test_from_der(self, samples):
+        assert PrivateKey.from_der(samples.get('PRIVATE_KEY_DER')).secret == samples.get('PRIVATE_KEY_BYTES')
 
     def test_ecdh(self):
         a = PrivateKey()
@@ -132,28 +123,39 @@ class TestPrivateKey:
 
 
 class TestPublicKey:
-    def test_from_secret(self):
-        assert PublicKey.from_secret(PRIVATE_KEY_BYTES).format() == PUBLIC_KEY_COMPRESSED
+    def test_from_secret(self, samples):
+        assert PublicKey.from_secret(samples.get('PRIVATE_KEY_BYTES')).format() == samples.get('PUBLIC_KEY_COMPRESSED')
 
-    def test_from_point(self):
-        assert PublicKey.from_point(PUBLIC_KEY_X, PUBLIC_KEY_Y).format() == PUBLIC_KEY_COMPRESSED
-
-    def test_from_signature_and_message(self):
-        assert (
-            PublicKey.from_secret(PRIVATE_KEY_BYTES).format()
-            == PublicKey.from_signature_and_message(RECOVERABLE_SIGNATURE, MESSAGE).format()
+    def test_from_point(self, samples):
+        assert PublicKey.from_point(samples.get('PUBLIC_KEY_X'), samples.get('PUBLIC_KEY_Y')).format() == samples.get(
+            'PUBLIC_KEY_COMPRESSED'
         )
 
-    def test_format(self):
-        assert PublicKey(PUBLIC_KEY_UNCOMPRESSED).format(compressed=True) == PUBLIC_KEY_COMPRESSED
-        assert PublicKey(PUBLIC_KEY_COMPRESSED).format(compressed=False) == PUBLIC_KEY_UNCOMPRESSED
+    def test_from_signature_and_message(self, samples):
+        assert (
+            PublicKey.from_secret(samples.get('PRIVATE_KEY_BYTES')).format()
+            == PublicKey.from_signature_and_message(
+                samples.get('RECOVERABLE_SIGNATURE'), samples.get('MESSAGE')
+            ).format()
+        )
 
-    def test_point(self):
-        assert PublicKey(PUBLIC_KEY_COMPRESSED).point() == (PUBLIC_KEY_X, PUBLIC_KEY_Y)
+    def test_format(self, samples):
+        assert PublicKey(samples.get('PUBLIC_KEY_UNCOMPRESSED')).format(compressed=True) == samples.get(
+            'PUBLIC_KEY_COMPRESSED'
+        )
+        assert PublicKey(samples.get('PUBLIC_KEY_COMPRESSED')).format(compressed=False) == samples.get(
+            'PUBLIC_KEY_UNCOMPRESSED'
+        )
 
-    def test_verify(self):
-        public_key = PublicKey(PUBLIC_KEY_COMPRESSED)
-        assert public_key.verify(SIGNATURE, MESSAGE)
+    def test_point(self, samples):
+        assert PublicKey(samples.get('PUBLIC_KEY_COMPRESSED')).point() == (
+            samples.get('PUBLIC_KEY_X'),
+            samples.get('PUBLIC_KEY_Y'),
+        )
+
+    def test_verify(self, samples):
+        public_key = PublicKey(samples.get('PUBLIC_KEY_COMPRESSED'))
+        assert public_key.verify(samples.get('SIGNATURE'), samples.get('MESSAGE'))
 
     def test_transform(self):
         x = urandom(32)
@@ -170,21 +172,24 @@ class TestPublicKey:
 
 
 class TestXonlyPubKey:
-    def test_parse_invalid(self):
+    def test_parse_invalid(self, samples):
         # Must be 32 bytes
         with pytest.raises(ValueError):
             PublicKeyXOnly.from_secret(bytes(33))
 
         # Must be an x coordinate for a valid point
         with pytest.raises(ValueError):
-            PublicKeyXOnly(X_ONLY_PUBKEY_INVALID)
+            PublicKeyXOnly(samples.get('X_ONLY_PUBKEY_INVALID'))
 
-    def test_roundtrip(self):
-        assert PublicKeyXOnly(X_ONLY_PUBKEY).format() == X_ONLY_PUBKEY
-        assert PublicKeyXOnly(PUBLIC_KEY_COMPRESSED[1:]).format() == PUBLIC_KEY_COMPRESSED[1:]
+    def test_roundtrip(self, samples):
+        assert PublicKeyXOnly(samples.get('X_ONLY_PUBKEY')).format() == samples.get('X_ONLY_PUBKEY')
+        assert (
+            PublicKeyXOnly(samples.get('PUBLIC_KEY_COMPRESSED')[1:]).format()
+            == samples.get('PUBLIC_KEY_COMPRESSED')[1:]
+        )
 
         # Test __eq__
-        assert PublicKeyXOnly(X_ONLY_PUBKEY) == PublicKeyXOnly(X_ONLY_PUBKEY)
+        assert PublicKeyXOnly(samples.get('X_ONLY_PUBKEY')) == PublicKeyXOnly(samples.get('X_ONLY_PUBKEY'))
 
     def test_tweak(self):
         # Taken from BIP341 test vectors.
@@ -205,3 +210,7 @@ class TestXonlyPubKey:
         pubkey.tweak_add(bytes.fromhex('6af9e28dbf9d6aaf027696e2598a5b3d056f5fd2355a7fd5a37a0e5008132d30'))
         assert pubkey.format() == bytes.fromhex('e4d810fd50586274face62b8a807eb9719cef49c04177cc6b76a9a4251d5450e')
         assert not pubkey.parity
+
+
+if __name__ == '__main__':
+    pytest.main(['-v', __file__])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,8 +17,6 @@ from coincurve.utils import (
     verify_signature,
 )
 
-from .samples import MESSAGE, PRIVATE_KEY_DER, PUBLIC_KEY_COMPRESSED, PUBLIC_KEY_UNCOMPRESSED, SIGNATURE
-
 
 class TestPadScalar:
     def test_correct(self):
@@ -70,13 +68,13 @@ def test_bytes_int_conversion_padded():
     assert int_to_bytes_padded(bytes_to_int(bytestr)) == bytestr
 
 
-def test_der_conversion():
-    assert pem_to_der(der_to_pem(PRIVATE_KEY_DER)) == PRIVATE_KEY_DER
+def test_der_conversion(samples):
+    assert pem_to_der(der_to_pem(samples.get('PRIVATE_KEY_DER'))) == samples.get('PRIVATE_KEY_DER')
 
 
-def test_verify_signature():
-    assert verify_signature(SIGNATURE, MESSAGE, PUBLIC_KEY_COMPRESSED)
-    assert verify_signature(SIGNATURE, MESSAGE, PUBLIC_KEY_UNCOMPRESSED)
+def test_verify_signature(samples):
+    assert verify_signature(samples.get('SIGNATURE'), samples.get('MESSAGE'), samples.get('PUBLIC_KEY_COMPRESSED'))
+    assert verify_signature(samples.get('SIGNATURE'), samples.get('MESSAGE'), samples.get('PUBLIC_KEY_UNCOMPRESSED'))
 
 
 def test_chunk_data():
@@ -104,3 +102,7 @@ def test_chunk_data():
         'e0',
         'b',
     ]
+
+
+if __name__ == '__main__':
+    pytest.main(['-v', __file__])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -69,12 +69,12 @@ def test_bytes_int_conversion_padded():
 
 
 def test_der_conversion(samples):
-    assert pem_to_der(der_to_pem(samples.get('PRIVATE_KEY_DER'))) == samples.get('PRIVATE_KEY_DER')
+    assert pem_to_der(der_to_pem(samples['PRIVATE_KEY_DER'])) == samples['PRIVATE_KEY_DER']
 
 
 def test_verify_signature(samples):
-    assert verify_signature(samples.get('SIGNATURE'), samples.get('MESSAGE'), samples.get('PUBLIC_KEY_COMPRESSED'))
-    assert verify_signature(samples.get('SIGNATURE'), samples.get('MESSAGE'), samples.get('PUBLIC_KEY_UNCOMPRESSED'))
+    assert verify_signature(samples['SIGNATURE'], samples['MESSAGE'], samples['PUBLIC_KEY_COMPRESSED'])
+    assert verify_signature(samples['SIGNATURE'], samples['MESSAGE'], samples['PUBLIC_KEY_UNCOMPRESSED'])
 
 
 def test_chunk_data():


### PR DESCRIPTION
The purpose is to be able to run pytest with the `cibuildwheel` feature. cibuildwheel install the tests in a manner that prevent `tests` to be recognized as a package and thus there is pretty much no way to `import samples` (at least none within the 50 commits I made on my branch to test it out!)