### PR TITLE
FEAT: add pkg config wrapper

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ def main():
     from setup_tools.commands import BdistWheel, EggInfo, Sdist, Develop
     from setup_tools.build_clib import BuildClib
     from setup_tools.build_ext import BuildCFFIForSharedLib, BuildExt
+    from setup_tools.support import call_pkg_config
 
     if has_system_lib():
 
@@ -57,12 +58,10 @@ def main():
             # ABI?: py_limited_api=True,
         )
 
-        extension.extra_compile_args = [
-            subprocess.check_output(['pkg-config', '--cflags-only-I', 'libsecp256k1']).strip().decode()  # noqa S603
-        ]
+        extension.extra_compile_args = [call_pkg_config(['--cflags-only-I'], 'libsecp256k1')]
         extension.extra_link_args = [
-            subprocess.check_output(['pkg-config', '--libs-only-L', 'libsecp256k1']).strip().decode(),  # noqa S603
-            subprocess.check_output(['pkg-config', '--libs-only-l', 'libsecp256k1']).strip().decode(),  # noqa S603
+            call_pkg_config(['--libs-only-L'], 'libsecp256k1'),
+            call_pkg_config(['--libs-only-l'], 'libsecp256k1'),
         ]
 
         if os.name == 'nt' or sys.platform == 'win32':

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 import os
 import os.path
 import platform
-import subprocess
 import sys
 from os.path import join
 from sys import path as PATH

--- a/setup_tools/support.py
+++ b/setup_tools/support.py
@@ -87,6 +87,20 @@ def subprocess_run(cmd, *, debug=False):
         raise e
 
 
+def call_pkg_config(options, library, *, debug=False):
+    """Calls pkg-config with the given options and returns the output."""
+    import shutil
+    from platform import system
+
+    if system() == 'Windows':
+        options.append('--dont-define-prefix')
+
+    pkg_config = shutil.which('pkg-config')
+    cmd = [pkg_config, *options, library]
+
+    return subprocess_run(cmd, debug=debug)
+
+
 def download_library(command):
     if command.dry_run:
         return

--- a/setup_tools/support.py
+++ b/setup_tools/support.py
@@ -69,11 +69,8 @@ def has_system_lib():
     return _has_system_lib
 
 
-def detect_dll(root_dir):
-    for fn in os.listdir(os.path.join(root_dir)):
-        if fn.endswith('.dll'):
-            return True
-    return False
+def detect_dll(root_dir: str):
+    return any(fn.endswith('.dll') for fn in os.listdir(os.path.join(root_dir)))
 
 
 def subprocess_run(cmd, *, debug=False):

--- a/setup_tools/support.py
+++ b/setup_tools/support.py
@@ -30,8 +30,7 @@ def build_flags(library, type_, path):
     os.environ['PKG_CONFIG_PATH'] = new_path + os.pathsep + os.environ.get('PKG_CONFIG_PATH', '')
 
     options = {'I': '--cflags-only-I', 'L': '--libs-only-L', 'l': '--libs-only-l'}
-    cmd = ['pkg-config', options[type_], library]
-    flags = subprocess_run(cmd)
+    flags = call_pkg_config([options[type_]], library)
     flags = list(flags.split())
 
     return [flag.strip(f'-{type_}') for flag in flags]
@@ -44,8 +43,8 @@ def _find_lib():
     from cffi import FFI
 
     try:
-        cmd = ['pkg-config', '--cflags-only-I', 'libsecp256k1']
-        includes = subprocess_run(cmd)
+        options = ['--cflags-only-I']
+        includes = call_pkg_config(options, 'libsecp256k1')
 
         return os.path.exists(os.path.join(includes[2:], 'secp256k1_ecdh.h'))
 


### PR DESCRIPTION
Adds a wrapper to pkg-config. So many times, I forgot to put this `dont-define-prefix` for windows and got lost in the error message until i printed the path (after several commits) and realized the issue