### PR TITLE
FIX: Correct a few configurations

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,7 +3,7 @@ branch = True
 
 source =
     src/coincurve
-    tests
+    # tests
 
 omit =
     */_windows_libsecp256k1.py
@@ -11,7 +11,7 @@ omit =
 
 [paths]
 source =
-   coincurve
+   src/coincurve
    .tox/*/lib/python*/site-packages/coincurve
    .tox/pypy*/site-packages/coincurve
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,8 @@ exclude = '''
   | \.mypy_cache
   | \.tox
   | \.venv
-  | _build
   | _cffi_build
+  | libsecp256k1
   | build
   | dist
 )/
@@ -50,6 +50,7 @@ lint.unfixable = [
 ]
 extend-exclude = [
     "tests/conftest.py",
+    "libsecp256k1"
 ]
 
 [tool.ruff.lint.isort]


### PR DESCRIPTION
The coverage was not updated with src/coincurve everywhere (it still worked apparently). I also removed the tests.
I noticed tox -e fmt (that I forget too often) complained about libsecp256k1 and a few times I missed issues
Also, lint picks-up a lonely .py deep within libsecp256k1, they may add more