### PR TITLE
FEAT: from setup to pyproject

### DIFF
--- a/.github/scripts/build-windows-wheels.sh
+++ b/.github/scripts/build-windows-wheels.sh
@@ -26,20 +26,18 @@ cp 64bit 32bit -R
 
 cd 64bit
 build_dll x86_64-w64-mingw32
-# Not sure why it ended-up being a -2.dll instead of -0.dll: Researching
+# As the API changes, the -x.dll will change to -y.dll, so we use a wildcard
 mv .libs/libsecp256k1-?.dll ../clean/src/coincurve/libsecp256k1.dll
 cd ../clean
-# python setup.py bdist_wheel --plat-name=win_amd64 -vvv
 python -m build --wheel -C="--build-option=bdist_wheel" -C="--build-option=--plat-name" -C="--build-option=win_amd64"
 rm src/coincurve/libsecp256k1.dll
 rm -rf build/temp.*
 
 cd ../32bit
 build_dll i686-w64-mingw32
-# Not sure why it ended-up being a -2.dll instead of -0.dll: Researching
+# As the API changes, the -x.dll will change to -y.dll, so we use a wildcard
 mv .libs/libsecp256k1-?.dll ../clean/src/coincurve/libsecp256k1.dll
 cd ../clean
-# python setup.py bdist_wheel --plat-name=win32
 python -m build --wheel -C="--build-option=bdist_wheel" -C="--build-option=--plat-name" -C="--build-option==win32"
 
 mv dist/* ../coincurve/dist

--- a/.github/scripts/build-windows-wheels.sh
+++ b/.github/scripts/build-windows-wheels.sh
@@ -29,7 +29,7 @@ build_dll x86_64-w64-mingw32
 # As the API changes, the -x.dll will change to -y.dll, so we use a wildcard
 mv .libs/libsecp256k1-?.dll ../clean/src/coincurve/libsecp256k1.dll
 cd ../clean
-python -m build --wheel -C="--build-option=bdist_wheel" -C="--build-option=--plat-name" -C="--build-option=win_amd64"
+python -m build --wheel -C="--build-option=--plat-name win_amd64"
 rm src/coincurve/libsecp256k1.dll
 rm -rf build/temp.*
 
@@ -38,7 +38,7 @@ build_dll i686-w64-mingw32
 # As the API changes, the -x.dll will change to -y.dll, so we use a wildcard
 mv .libs/libsecp256k1-?.dll ../clean/src/coincurve/libsecp256k1.dll
 cd ../clean
-python -m build --wheel -C="--build-option=bdist_wheel" -C="--build-option=--plat-name" -C="--build-option==win32"
+python -m build --wheel -C="--build-option--plat-name win32"
 
 mv dist/* ../coincurve/dist
 cd ../coincurve

--- a/.github/scripts/build-windows-wheels.sh
+++ b/.github/scripts/build-windows-wheels.sh
@@ -29,7 +29,8 @@ build_dll x86_64-w64-mingw32
 # Not sure why it ended-up being a -2.dll instead of -0.dll: Researching
 mv .libs/libsecp256k1-?.dll ../clean/src/coincurve/libsecp256k1.dll
 cd ../clean
-python setup.py bdist_wheel --plat-name=win_amd64 -vvv
+# python setup.py bdist_wheel --plat-name=win_amd64 -vvv
+python -m build --wheel --plat-name=win_amd64
 rm src/coincurve/libsecp256k1.dll
 rm -rf build/temp.*
 
@@ -38,7 +39,8 @@ build_dll i686-w64-mingw32
 # Not sure why it ended-up being a -2.dll instead of -0.dll: Researching
 mv .libs/libsecp256k1-?.dll ../clean/src/coincurve/libsecp256k1.dll
 cd ../clean
-python setup.py bdist_wheel --plat-name=win32
+# python setup.py bdist_wheel --plat-name=win32
+python -m build --wheel --plat-name=win32
 
 mv dist/* ../coincurve/dist
 cd ../coincurve

--- a/.github/scripts/build-windows-wheels.sh
+++ b/.github/scripts/build-windows-wheels.sh
@@ -30,7 +30,7 @@ build_dll x86_64-w64-mingw32
 mv .libs/libsecp256k1-?.dll ../clean/src/coincurve/libsecp256k1.dll
 cd ../clean
 # python setup.py bdist_wheel --plat-name=win_amd64 -vvv
-python -m build --wheel --plat-name=win_amd64
+python -m build --wheel -C="--build-option=bdist_wheel" -C="--build-option=--plat-name" -C="--build-option=win_amd64"
 rm src/coincurve/libsecp256k1.dll
 rm -rf build/temp.*
 
@@ -40,7 +40,7 @@ build_dll i686-w64-mingw32
 mv .libs/libsecp256k1-?.dll ../clean/src/coincurve/libsecp256k1.dll
 cd ../clean
 # python setup.py bdist_wheel --plat-name=win32
-python -m build --wheel --plat-name=win32
+python -m build --wheel -C="--build-option=bdist_wheel" -C="--build-option=--plat-name" -C="--build-option==win32"
 
 mv dist/* ../coincurve/dist
 cd ../coincurve

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ Documentation = "https://ofek.dev/coincurve/"
 Repository = "https://github.com/ofek/coincurve"
 "Bug Tracker" = "https://github.com/ofek/coincurve/issues"
 
+# --- setuptools ---
 [tool.setuptools]
 packages = ['coincurve']
 package-dir = {'' = 'src'}
@@ -56,6 +57,8 @@ package-data = {'coincurve' = ['py.typed']}
 [tool.setuptools.dynamic]
 version = {attr = "coincurve._version.__version__"}
 readme = {content-type = "text/markdown", file = "README.md"}
+
+# --- hatch ---
 
 [tool.pytest.ini_options]
 addopts = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ Repository = "https://github.com/ofek/coincurve"
 [tool.setuptools]
 packages = ['coincurve']
 package-dir = {'' = 'src'}
+package-data = {'coincurve' = ['py.typed']}
 
 [tool.setuptools.dynamic]
 version = {attr = "coincurve._version.__version__"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,60 @@
 [build-system]
-requires = ["setuptools>=61", "cffi>=1.3.0", "requests"]
+requires = ["setuptools>=61", "cffi>=1.3.0", "requests", "setuptools-scm", 'asn1crypto']
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "coincurve"
+authors = [
+    { name="Ofek Lev", email="oss@ofek.dev" },
+]
+description = "Cross-platform Python CFFI bindings for libsecp256k1"
+keywords = ["secp256k1", "crypto", "elliptic curves", "bitcoin", "ethereum", "cryptocurrency"]
+requires-python = ">=3.8"
+dependencies = [
+    "asn1crypto",
+    "cffi>=1.3.0"
+]
+classifiers = [
+    'Development Status :: 5 - Production/Stable',
+    'Intended Audience :: Developers',
+    'License :: OSI Approved :: MIT License',
+    'License :: OSI Approved :: Apache Software License',
+    'Natural Language :: English',
+    'Operating System :: OS Independent',
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.9',
+    'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: Implementation :: CPython',
+    'Programming Language :: Python :: Implementation :: PyPy',
+    'Topic :: Software Development :: Libraries',
+    'Topic :: Security :: Cryptography',
+]
+dynamic = ['version', 'readme']
+
+[project.optional-dependencies]
+dev = [
+    "coverage",
+    "pytest",
+    "pytest-benchmark"
+]
+
+[project.urls]
+Homepage = "https://github.com/ofek/coincurve"
+Documentation = "https://ofek.dev/coincurve/"
+Repository = "https://github.com/ofek/coincurve"
+"Bug Tracker" = "https://github.com/ofek/coincurve/issues"
+
+[tool.setuptools]
+packages = ['coincurve']
+package-dir = {'' = 'src'}
+
+[tool.setuptools.dynamic]
+version = {attr = "coincurve._version.__version__"}
+readme = {content-type = "text/markdown", file = "README.md"}
 
 [tool.pytest.ini_options]
 addopts = [

--- a/setup.py
+++ b/setup.py
@@ -29,11 +29,6 @@ UPSTREAM_REF = os.getenv('COINCURVE_UPSTREAM_REF') or '1ad5185cd42c0636104129fcc
 
 LIB_TARBALL_URL = f'https://github.com/bitcoin-core/secp256k1/archive/{UPSTREAM_REF}.tar.gz'
 
-globals_ = {}
-with open(join(COINCURVE_ROOT_DIR, 'src', 'coincurve', '_version.py')) as fp:
-    exec(fp.read(), globals_)  # noqa S102
-    __version__ = globals_['__version__']
-
 package_data = {'coincurve': ['py.typed']}
 
 

--- a/setup.py
+++ b/setup.py
@@ -34,13 +34,6 @@ with open(join(COINCURVE_ROOT_DIR, 'src', 'coincurve', '_version.py')) as fp:
     exec(fp.read(), globals_)  # noqa S102
     __version__ = globals_['__version__']
 
-# We require setuptools >= 3.3
-if [int(i) for i in setuptools_version.split('.', 2)[:2]] < [3, 3]:
-    raise SystemExit(
-        f'Your setuptools version ({setuptools_version}) is too old to correctly install this package. Please upgrade '
-        f'to a newer version (>= 3.3).'
-    )
-
 package_data = {'coincurve': ['py.typed']}
 
 

--- a/setup.py
+++ b/setup.py
@@ -119,56 +119,8 @@ def main():
             )
 
     setup(
-        name='coincurve',
-        version=__version__,
-
-        description='Cross-platform Python CFFI bindings for libsecp256k1',
-        long_description=open('README.md', 'r').read(),
-        long_description_content_type='text/markdown',
-        author_email='Ofek Lev <oss@ofek.dev>',
-        license='MIT OR Apache-2.0',
-
-        python_requires='>=3.8',
-        setup_requires=['cffi>=1.3.0'],
-        install_requires=['asn1crypto', 'cffi>=1.3.0'],
-
-        packages=['coincurve'],
-        package_dir={'coincurve': 'src/coincurve'},
-
         distclass=Distribution,
         zip_safe=False,
-
-        project_urls={
-            'Documentation': 'https://ofek.dev/coincurve/',
-            'Issues': 'https://github.com/ofek/coincurve/issues',
-            'Source': 'https://github.com/ofek/coincurve',
-        },
-        keywords=[
-            'secp256k1',
-            'crypto',
-            'elliptic curves',
-            'bitcoin',
-            'ethereum',
-            'cryptocurrency',
-        ],
-        classifiers=[
-            'Development Status :: 5 - Production/Stable',
-            'Intended Audience :: Developers',
-            'License :: OSI Approved :: MIT License',
-            'License :: OSI Approved :: Apache Software License',
-            'Natural Language :: English',
-            'Operating System :: OS Independent',
-            'Programming Language :: Python :: 3',
-            'Programming Language :: Python :: 3.8',
-            'Programming Language :: Python :: 3.9',
-            'Programming Language :: Python :: 3.10',
-            'Programming Language :: Python :: 3.11',
-            'Programming Language :: Python :: 3.12',
-            'Programming Language :: Python :: Implementation :: CPython',
-            'Programming Language :: Python :: Implementation :: PyPy',
-            'Topic :: Software Development :: Libraries',
-            'Topic :: Security :: Cryptography',
-        ],
         **setup_kwargs
     )
 

--- a/setup.py
+++ b/setup.py
@@ -29,9 +29,6 @@ UPSTREAM_REF = os.getenv('COINCURVE_UPSTREAM_REF') or '1ad5185cd42c0636104129fcc
 
 LIB_TARBALL_URL = f'https://github.com/bitcoin-core/secp256k1/archive/{UPSTREAM_REF}.tar.gz'
 
-package_data = {'coincurve': ['py.typed']}
-
-
 def main():
     from setup_tools.commands import BdistWheel, EggInfo, Sdist, Develop
     from setup_tools.build_clib import BuildClib
@@ -84,7 +81,6 @@ def main():
                 def is_pure(self):
                     return False
 
-            package_data['coincurve'].append('libsecp256k1.dll')
             setup_kwargs = {}
 
         else:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import sys
 from os.path import join
 from sys import path as PATH
 
-from setuptools import Distribution as _Distribution, setup, __version__ as setuptools_version
+from setuptools import Distribution as _Distribution, setup
 from setuptools.extension import Extension
 
 # Define the package root directory and add it to the system path
@@ -28,6 +28,7 @@ MAKE = 'gmake' if platform.system() in ['FreeBSD', 'OpenBSD'] else 'make'
 UPSTREAM_REF = os.getenv('COINCURVE_UPSTREAM_REF') or '1ad5185cd42c0636104129fcc9f6a4bf9c67cc40'
 
 LIB_TARBALL_URL = f'https://github.com/bitcoin-core/secp256k1/archive/{UPSTREAM_REF}.tar.gz'
+
 
 def main():
     from setup_tools.commands import BdistWheel, EggInfo, Sdist, Develop


### PR DESCRIPTION
Let's try to transition more metadate from setup to pyproject, this way when we hatch, it'll be simpler and both setuptools and hatchling may be tested in quasi-parallel