### PR TITLE
PEP 639 compliance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 build-backend = "hatchling.build"
 requires = [
-    "hatchling>=1.24.2",
+    "hatchling>=1.27.0",
     "cffi",
     "setuptools",
     "scikit-build-core>=0.9.0",
@@ -28,12 +28,14 @@ keywords = [
 ]
 readme = "README.md"
 license = "MIT OR Apache-2.0"
+license-files = [
+    "LICENSE-APACHE",
+    "LICENSE-MIT",
+]
 requires-python = ">=3.9"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
-    "License :: OSI Approved :: Apache Software License",
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
- Explictly list license files.
- Bump hatch version accordingly.
- Remove licensing information from Trove classifiers.