### PR TITLE
Get rid of setuptools 

### DIFF
--- a/.conda/environment-dev.yml
+++ b/.conda/environment-dev.yml
@@ -10,5 +10,4 @@ dependencies:
   - pytest
   - pytest-benchmark
   - python =3.12
-  - setuptools >=61
   - tox-conda

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ build-backend = "hatchling.build"
 requires = [
     "hatchling>=1.27.0",
     "cffi",
-    "setuptools",
     "scikit-build-core>=0.9.0",
     "pkgconf; sys_platform == 'win32'",
 ]


### PR DESCRIPTION
Actually, what is setuptools used for? I see it can also be found here:
https://github.com/ofek/coincurve/blob/775b07ed80e0df9fac12ef367a254860a79500b5/.conda/environment-dev.yml#L13