### PR TITLE
Delete linkchecker config file

### DIFF
--- a/.linkcheckerrc
+++ b/.linkcheckerrc
@@ -1,1 +1,0 @@
-[AnchorCheck]


### PR DESCRIPTION
I believe it had been added inadvertently:
- It was intoduced by presumably unrelated  2f51f35 / #175.
- It is empty.