### PR TITLE
Bump GitHub Action pypa/cibuildwheel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
         path: coverage.xml
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
 
     - name: Benchmark
       run: uv run --python-preference system scripts/bench.py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,8 +33,6 @@ env:
     assert a.ecdh(b.public_key.format())==b.ecdh(a.public_key.format())
     " &&
     python -m pytest {project}
-  CIBW_SKIP: >
-      pp*
 
 jobs:
   test:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,7 +119,7 @@ jobs:
     - uses: actions/checkout@v5
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.23
+      uses: pypa/cibuildwheel@v3.2.0
 
     - uses: actions/upload-artifact@v4
       with:
@@ -159,7 +159,7 @@ jobs:
     - uses: actions/checkout@v5
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.23
+      uses: pypa/cibuildwheel@v3.2.0
 
     - uses: actions/upload-artifact@v4
       with:
@@ -181,7 +181,7 @@ jobs:
         python-version: ${{ env.PYTHON_VERSION }}
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.23
+      uses: pypa/cibuildwheel@v3.2.0
       env:
         CIBW_ARCHS_WINDOWS: 'AMD64'
         CIBW_BEFORE_ALL: choco install -y --no-progress --no-color cmake>=3.28
@@ -202,7 +202,7 @@ jobs:
     - uses: actions/checkout@v5
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.23
+      uses: pypa/cibuildwheel@v3.2.0
       env:
         COINCURVE_CROSS_HOST: 'arm64'
         CIBW_ARCHS_WINDOWS: 'ARM64'
@@ -251,7 +251,7 @@ jobs:
         platforms: arm64
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.23
+      uses: pypa/cibuildwheel@v3.2.0
       env:
         CIBW_ARCHS_LINUX: aarch64
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,6 +178,9 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
 
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+
     - name: Build wheels
       uses: pypa/cibuildwheel@v3.2.0
       env:
@@ -198,6 +201,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v5
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
 
     - name: Build wheels
       uses: pypa/cibuildwheel@v3.2.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ env:
     assert a.ecdh(b.public_key.format())==b.ecdh(a.public_key.format())
     " &&
     python -m pytest {project}
+  SKBUILD_LOGGING_LEVEL: 'DEBUG'
 
 jobs:
   test:

--- a/.github/workflows/verify_conda_build.yml
+++ b/.github/workflows/verify_conda_build.yml
@@ -35,8 +35,6 @@ env:
     assert a.ecdh(b.public_key.format())==b.ecdh(a.public_key.format())
     " &&
     python -m pytest {project}
-  CIBW_SKIP: >
-      pp*
 
 jobs:
   test:

--- a/.github/workflows/verify_conda_build.yml
+++ b/.github/workflows/verify_conda_build.yml
@@ -70,7 +70,7 @@ jobs:
       run: LD_LIBRARY_PATH=$CONDA_PREFIX/lib hatch test
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
 
     - name: Benchmark
       run: LD_LIBRARY_PATH=$CONDA_PREFIX/lib uv run --python-preference system scripts/bench.py

--- a/.github/workflows/verify_shared_build.yml
+++ b/.github/workflows/verify_shared_build.yml
@@ -33,6 +33,7 @@ env:
     " &&
     python -m pytest {project}
   CIBW_TEST_SKIP: "*-macosx_arm64"
+  SKBUILD_LOGGING_LEVEL: 'DEBUG'
 
 jobs:
   test:

--- a/.github/workflows/verify_shared_build.yml
+++ b/.github/workflows/verify_shared_build.yml
@@ -66,7 +66,7 @@ jobs:
       run: hatch test
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
 
     - name: Benchmark
       run: uv run --python-preference system scripts/bench.py

--- a/.github/workflows/verify_shared_build.yml
+++ b/.github/workflows/verify_shared_build.yml
@@ -81,7 +81,7 @@ jobs:
     - uses: actions/checkout@v5
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.23
+      uses: pypa/cibuildwheel@v3.2.0
 
   macos-wheels-x86_64:
     name: Build macOS wheels for x86-64
@@ -109,7 +109,7 @@ jobs:
     - uses: actions/checkout@v5
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.23
+      uses: pypa/cibuildwheel@v3.2.0
 
   windows-wheels-x86_64:
     name: Build Windows wheels for x86-64
@@ -125,7 +125,7 @@ jobs:
         python-version: ${{ env.PYTHON_VERSION }}
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.23
+      uses: pypa/cibuildwheel@v3.2.0
       env:
         CIBW_ARCHS_WINDOWS: 'AMD64'
         CIBW_BEFORE_ALL: choco install -y --no-progress --no-color cmake>=3.28
@@ -140,7 +140,7 @@ jobs:
     - uses: actions/checkout@v5
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.23
+      uses: pypa/cibuildwheel@v3.2.0
       env:
         COINCURVE_CROSS_HOST: 'arm64'
         CIBW_ARCHS_WINDOWS: 'ARM64'

--- a/.github/workflows/verify_shared_build.yml
+++ b/.github/workflows/verify_shared_build.yml
@@ -90,6 +90,9 @@ jobs:
     steps:
     - uses: actions/checkout@v5
 
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+
     - name: Build wheels
       uses: pypa/cibuildwheel@v3.2.0
       env:
@@ -105,6 +108,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v5
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
 
     - name: Build wheels
       uses: pypa/cibuildwheel@v3.2.0
@@ -122,6 +128,9 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
 
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+
     - name: Build wheels
       uses: pypa/cibuildwheel@v3.2.0
       env:
@@ -136,6 +145,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v5
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
 
     - name: Build wheels
       uses: pypa/cibuildwheel@v3.2.0

--- a/.github/workflows/verify_shared_build.yml
+++ b/.github/workflows/verify_shared_build.yml
@@ -33,8 +33,6 @@ env:
     " &&
     python -m pytest {project}
   CIBW_TEST_SKIP: "*-macosx_arm64"
-  CIBW_SKIP: >
-      pp*
 
 jobs:
   test:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,4 +142,5 @@ warn_unused_ignores = true
 
 # --- cibuildwheel ---
 [tool.cibuildwheel]
+build-frontend = "build[uv]"
 skip = "cp3??t-*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,3 +139,7 @@ pretty = true
 show_column_numbers = true
 warn_no_return = false
 warn_unused_ignores = true
+
+# --- cibuildwheel ---
+[tool.cibuildwheel]
+skip = "cp3??t-*"


### PR DESCRIPTION
This should help fix today's CI failures.

**Edit:** Actually, it doesn't help. [Quay](https://quay.io/) is currently down with 502 errors (confirmed by [status.redhat.com](https://status.redhat.com/)).

<img width="1065" height="269" alt="Screen capture 2025-10-20 09-44-30" src="https://github.com/user-attachments/assets/8663db02-58ec-4e6b-8e0b-8048a5b997dc" />

Still, it's a good idea to update!