### PR TITLE
Test free threading

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t"]
 
     steps:
     - name: Checkout code

--- a/hatch.toml
+++ b/hatch.toml
@@ -9,6 +9,9 @@ dependencies = ["ruff==0.13.0"]
 [envs.hatch-test]
 dev-mode = false
 
+[[envs.hatch-test.matrix]]
+python = ["3.14t", "3.14", "3.13", "3.12", "3.11", "3.10", "3.9"]
+
 [envs.types]
 dependencies = [
   "mypy",


### PR DESCRIPTION
Fixes #212.

* Support for free threaded Python requires CFFI [v2.0.0](https://cffi.readthedocs.io/en/stable/whatsnew.html#v2-0-0).
* CFFI [v2.0.0](https://cffi.readthedocs.io/en/stable/whatsnew.html#v2-0-0) does not support CPython 3.13t, only CPython 3.14t. 

> Added support for free threaded CPython (3.14t+ only). ([#178](https://github.com/python-cffi/cffi/pull/178)) Note that the free-threaded build does not yet support building extensions with the limited API, so you must set py_limited_api=False when building extensions for the free-threaded build. CPython 3.13t is not currently supported due to differences in sync primitive behavior from 3.14t that result in segfaults.