### PR TITLE
Hack to build fastecdsa

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,6 +85,12 @@ jobs:
 
     - name: Benchmark
       run: uv run --python-preference system scripts/bench.py
+      # Required to build fastecdsa on macOS (experienced with Python 3.14 but might affect earlier versions too)
+      # https://github.com/AntonKueltz/fastecdsa/issues/74#issuecomment-932757298
+      # https://stackoverflow.com/questions/68827486/cannot-link-gmp-library-not-found-for-lgmp
+      env:
+        CFLAGS: -I/opt/homebrew/include
+        LDFLAGS: -L/opt/homebrew/lib
 
   coverage:
     name: Upload coverage


### PR DESCRIPTION
Fixes the effect of GitHub Action cache misses for key `setup-uv-1-aarch64-apple-darwin-3.14.0-no-dependency-glob` experienced in #203.

But then it's unclear why this kind of failure affects only Python 3.14. Other versions of Python should have failed as well when creating the cache. While I haven't got to the bottom of this, this is a common issue after installing GMP with Homebrew on macOS, and we apply the currently preferred workaround:
*  [Cannot link gmp: library not found for -lgmp](https://stackoverflow.com/questions/68827486/cannot-link-gmp-library-not-found-for-lgmp)

I haven't found a way to define environment variables `CFLAGS`/`LDFLAGS` for macOS only.