### PR TITLE
Various fixes to get publish workflow working again

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -238,16 +238,10 @@ jobs:
     name: Build Linux wheels for ARM64
     needs:
     - test
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.event.ref, 'refs/tags'))
+    runs-on: ubuntu-24.04-arm
 
     steps:
     - uses: actions/checkout@v5
-
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-      with:
-        platforms: arm64
 
     - name: Build wheels
       uses: pypa/cibuildwheel@v4.1.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,7 +196,7 @@ jobs:
     name: Build Windows wheels for ARM64
     needs:
     - test
-    runs-on: windows-latest
+    runs-on: windows-11-arm
 
     steps:
     - uses: actions/checkout@v5
@@ -204,7 +204,6 @@ jobs:
     - name: Build wheels
       uses: pypa/cibuildwheel@v4.1.0
       env:
-        COINCURVE_CROSS_HOST: 'arm64'
         CIBW_ARCHS_WINDOWS: 'ARM64'
         CIBW_BEFORE_ALL: choco install -y --no-progress --no-color cmake>=3.28
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,7 +141,7 @@ jobs:
       env:
         CIBW_ARCHS_MACOS: x86_64
         CIBW_SKIP: "cp314t-*"
-        MACOSX_DEPLOYMENT_TARGET: 10.13
+        MACOSX_DEPLOYMENT_TARGET: 10.15
 
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - name: Checkout code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,7 +119,7 @@ jobs:
     - uses: actions/checkout@v5
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.23
+      uses: pypa/cibuildwheel@v4.1.0
 
     - uses: actions/upload-artifact@v4
       with:
@@ -137,7 +137,7 @@ jobs:
     - uses: actions/checkout@v5
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v3.2.0
+      uses: pypa/cibuildwheel@v4.1.0
       env:
         CIBW_ARCHS_MACOS: x86_64
         CIBW_SKIP: "cp314t-*"
@@ -159,7 +159,7 @@ jobs:
     - uses: actions/checkout@v5
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.23
+      uses: pypa/cibuildwheel@v4.1.0
 
     - uses: actions/upload-artifact@v4
       with:
@@ -181,7 +181,7 @@ jobs:
         python-version: ${{ env.PYTHON_VERSION }}
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.23
+      uses: pypa/cibuildwheel@v4.1.0
       env:
         CIBW_ARCHS_WINDOWS: 'AMD64'
         CIBW_BEFORE_ALL: choco install -y --no-progress --no-color cmake>=3.28
@@ -202,7 +202,7 @@ jobs:
     - uses: actions/checkout@v5
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.23
+      uses: pypa/cibuildwheel@v4.1.0
       env:
         COINCURVE_CROSS_HOST: 'arm64'
         CIBW_ARCHS_WINDOWS: 'ARM64'
@@ -251,7 +251,7 @@ jobs:
         platforms: arm64
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.23
+      uses: pypa/cibuildwheel@v4.1.0
       env:
         CIBW_ARCHS_LINUX: aarch64
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,7 @@ env:
     python -m pytest {project}
   CIBW_SKIP: >
       pp*
+      cp314t-*
 
 jobs:
   test:
@@ -140,7 +141,6 @@ jobs:
       uses: pypa/cibuildwheel@v4.1.0
       env:
         CIBW_ARCHS_MACOS: x86_64
-        CIBW_SKIP: "cp314t-*"
         MACOSX_DEPLOYMENT_TARGET: 10.15
 
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/verify_shared_build.yml
+++ b/.github/workflows/verify_shared_build.yml
@@ -97,7 +97,7 @@ jobs:
       env:
         CIBW_ARCHS_MACOS: x86_64
         CIBW_SKIP: "cp314t-*"
-        MACOSX_DEPLOYMENT_TARGET: 10.13
+        MACOSX_DEPLOYMENT_TARGET: 10.15
 
   macos-wheels-arm64:
     name: Build macOS wheels for ARM64

--- a/.github/workflows/verify_shared_build.yml
+++ b/.github/workflows/verify_shared_build.yml
@@ -35,6 +35,7 @@ env:
   CIBW_TEST_SKIP: "*-macosx_arm64"
   CIBW_SKIP: >
       pp*
+      cp314t-*
 
 jobs:
   test:
@@ -96,7 +97,6 @@ jobs:
       uses: pypa/cibuildwheel@v4.1.0
       env:
         CIBW_ARCHS_MACOS: x86_64
-        CIBW_SKIP: "cp314t-*"
         MACOSX_DEPLOYMENT_TARGET: 10.15
 
   macos-wheels-arm64:

--- a/.github/workflows/verify_shared_build.yml
+++ b/.github/workflows/verify_shared_build.yml
@@ -81,7 +81,7 @@ jobs:
     - uses: actions/checkout@v5
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.23
+      uses: pypa/cibuildwheel@v4.1.0
 
   macos-wheels-x86_64:
     name: Build macOS wheels for x86-64
@@ -93,7 +93,7 @@ jobs:
     - uses: actions/checkout@v5
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v3.2.0
+      uses: pypa/cibuildwheel@v4.1.0
       env:
         CIBW_ARCHS_MACOS: x86_64
         CIBW_SKIP: "cp314t-*"
@@ -109,7 +109,7 @@ jobs:
     - uses: actions/checkout@v5
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.23
+      uses: pypa/cibuildwheel@v4.1.0
 
   windows-wheels-x86_64:
     name: Build Windows wheels for x86-64
@@ -125,7 +125,7 @@ jobs:
         python-version: ${{ env.PYTHON_VERSION }}
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.23
+      uses: pypa/cibuildwheel@v4.1.0
       env:
         CIBW_ARCHS_WINDOWS: 'AMD64'
         CIBW_BEFORE_ALL: choco install -y --no-progress --no-color cmake>=3.28
@@ -140,7 +140,7 @@ jobs:
     - uses: actions/checkout@v5
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.23
+      uses: pypa/cibuildwheel@v4.1.0
       env:
         COINCURVE_CROSS_HOST: 'arm64'
         CIBW_ARCHS_WINDOWS: 'ARM64'

--- a/.github/workflows/verify_shared_build.yml
+++ b/.github/workflows/verify_shared_build.yml
@@ -134,7 +134,7 @@ jobs:
     name: Build Windows wheels for ARM64
     needs:
     - test
-    runs-on: windows-latest
+    runs-on: windows-11-arm
 
     steps:
     - uses: actions/checkout@v5
@@ -142,6 +142,5 @@ jobs:
     - name: Build wheels
       uses: pypa/cibuildwheel@v4.1.0
       env:
-        COINCURVE_CROSS_HOST: 'arm64'
         CIBW_ARCHS_WINDOWS: 'ARM64'
         CIBW_BEFORE_ALL: choco install -y --no-progress --no-color cmake>=3.28

--- a/docs/install.md
+++ b/docs/install.md
@@ -15,11 +15,11 @@ Binary wheels are available for most platforms and require at least version `19.
 | | | | | |
 | --- | --- | --- | --- | --- |
 | | macOS | Windows | Linux (glibc) | Linux (musl) |
-| CPython 3.9 | <ul><li>x86_64</li><li>ARM64</li></ul> | <ul><li>x86_64</li><li>ARM64</li></ul> | <ul><li>x86_64</li><li>i686</li><li>AArch64</li></ul> | <ul><li>x86_64</li><li>i686</li><li>AArch64</li></ul> |
 | CPython 3.10 | <ul><li>x86_64</li><li>ARM64</li></ul> | <ul><li>x86_64</li><li>ARM64</li></ul> | <ul><li>x86_64</li><li>i686</li><li>AArch64</li></ul> | <ul><li>x86_64</li><li>i686</li><li>AArch64</li></ul> |
 | CPython 3.11 | <ul><li>x86_64</li><li>ARM64</li></ul> | <ul><li>x86_64</li><li>ARM64</li></ul> | <ul><li>x86_64</li><li>i686</li><li>AArch64</li></ul> | <ul><li>x86_64</li><li>i686</li><li>AArch64</li></ul> |
 | CPython 3.12 | <ul><li>x86_64</li><li>ARM64</li></ul> | <ul><li>x86_64</li><li>ARM64</li></ul> | <ul><li>x86_64</li><li>i686</li><li>AArch64</li></ul> | <ul><li>x86_64</li><li>i686</li><li>AArch64</li></ul> |
 | CPython 3.13 | <ul><li>x86_64</li><li>ARM64</li></ul> | <ul><li>x86_64</li><li>ARM64</li></ul> | <ul><li>x86_64</li><li>i686</li><li>AArch64</li></ul> | <ul><li>x86_64</li><li>i686</li><li>AArch64</li></ul> |
+| CPython 3.14 | <ul><li>x86_64</li><li>ARM64</li></ul> | <ul><li>x86_64</li><li>ARM64</li></ul> | <ul><li>x86_64</li><li>i686</li><li>AArch64</li></ul> | <ul><li>x86_64</li><li>i686</li><li>AArch64</li></ul> |
 
 ## Source
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ license-files = [
     "LICENSE-MIT",
     "NOTICE",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",

--- a/src/coincurve/der.py
+++ b/src/coincurve/der.py
@@ -130,7 +130,7 @@ def encode_der(private_key: bytes, public_key: bytes | None = None) -> bytes:
     ec_key_seq.extend(ec_key_buffer)
 
     # Wrap in octet string for outer structure
-    ec_key_os = encode_octet_string(ec_key_seq)
+    ec_key_os = encode_octet_string(bytes(ec_key_seq))
 
     # Build the outer PKCS#8 structure
     result = bytearray([SEQUENCE_TAG])


### PR DESCRIPTION
Hi, we are in need of coincurve with python 3.14 compatibility so i forked your repo and applied these fixes to publish my own wheels. You might want these!


The macos benchmark step on python 3.14 is still failing, and i skipped that one on my repo.